### PR TITLE
i1436 - expose orderly server port and standardise on 8321

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -8,7 +8,7 @@ main_args <- function(args) {
     optparse::make_option("--port",
                           help = "Port to run on",
                           type = "integer",
-                          default = "8123"),
+                          default = "8321"),
     optparse::make_option("--host",
                           help = "IP address owned by this server",
                           default = "0.0.0.0",

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ docker pull $IMAGE
 mkdir orderly
 docker run --rm --entrypoint Rscript -v ${PWD}/orderly:/orderly --user ${UID} $IMAGE -e 'orderly:::prepare_orderly_git_example("/orderly")'
 docker run --rm --entrypoint Rscript -v ${PWD}/orderly:/orderly --user ${UID} $IMAGE -e 'orderly::orderly_rebuild("/orderly")'
-docker run --rm -p 8123:8123 -v ${PWD}/orderly:/orderly --user ${UID} $IMAGE /orderly
+docker run --rm -p 8321:8321 -v ${PWD}/orderly:/orderly --user ${UID} $IMAGE /orderly
 ```
 
 then
 
 ```
-$ curl -s -X GET http://localhost:8123/ | jq
+$ curl -s -X GET http://localhost:8321/ | jq
 {
   "status": "success",
   "data": {
@@ -57,7 +57,7 @@ $ curl -s -X GET http://localhost:8123/ | jq
 Endpoints are shown in [the spec](tests/testthat/spec/spec.md)
 
 ```
-$ curl -s -X POST http://localhost:8123/v1/reports/example/run/ | jq
+$ curl -s -X POST http://localhost:8321/v1/reports/example/run/ | jq
 {
   "status": "success",
   "data": {
@@ -70,7 +70,7 @@ $ curl -s -X POST http://localhost:8123/v1/reports/example/run/ | jq
 ```
 
 ```
-$ curl -s -X GET http://localhost:8123/v1/reports/flirtatious_komododragon/status/?output=true | jq
+$ curl -s -X GET http://localhost:8321/v1/reports/flirtatious_komododragon/status/?output=true | jq
 {
   "status": "success",
   "data": {
@@ -112,7 +112,7 @@ $ curl -s -X GET http://localhost:8123/v1/reports/flirtatious_komododragon/statu
 Publish a report (or unpublish with `?value=false`)
 
 ```
-$ curl -s -X POST http://localhost:8123/v1/reports/example/20170920-110037-69eede6a/publish/ | jq
+$ curl -s -X POST http://localhost:8321/v1/reports/example/20170920-110037-69eede6a/publish/ | jq
 {
   "status": "success",
   "data": true,
@@ -123,7 +123,7 @@ $ curl -s -X POST http://localhost:8123/v1/reports/example/20170920-110037-69eed
 Rebuild the orderly index:
 
 ```
-$ curl -s -X POST http://localhost:8123/v1/reports/rebuild/ | jq
+$ curl -s -X POST http://localhost:8321/v1/reports/rebuild/ | jq
 {
   "status": "success",
   "data": null,

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,4 +14,6 @@ RUN R CMD INSTALL /orderly.server && \
   Rscript -e 'orderly.server:::write_script("/usr/bin")' && \
   rm -rf /orderly.server
 
+EXPOSE 8321
+
 ENTRYPOINT ["orderly.server"]

--- a/docker/use.R
+++ b/docker/use.R
@@ -1,2 +1,2 @@
 Rscript -e 'orderly:::prepare_orderly_example("interactive", "orderly")'
-docker run --rm -v ${PWD}/orderly:/orderly -p 8123:8123 --user $UID docker.montagu.dide.ic.ac.uk:5000/orderly.server:i648 --help
+docker run --rm -v ${PWD}/orderly:/orderly -p 8321:8321 --user $UID docker.montagu.dide.ic.ac.uk:5000/orderly.server:master --help

--- a/tests/testthat/helper-orderly.server.R
+++ b/tests/testthat/helper-orderly.server.R
@@ -1,4 +1,4 @@
-test_server <- function(port = 8123) {
+test_server <- function(port = 8321) {
   path <- orderly:::prepare_orderly_example("interactive")
   server(path, port, "127.0.0.1")
 }
@@ -53,7 +53,7 @@ make_api_url <- function(port) {
 
 Sys.setenv(R_TESTS = "")
 
-start_test_server <- function(path = NULL, port = 8123,
+start_test_server <- function(path = NULL, port = 8321,
                               log = NULL,
                               fork = TRUE) {
   if (is.null(log)) {


### PR DESCRIPTION
There was a typo of 8123 and 8321 floating around since the beginning
of this - we use 8321 in our actual deployments but here we default
to 8123.  This is surprisingly hard to detect when it goes wrong
