### PR TITLE
Point at version of orderly with R 3.5

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.montagu.dide.ic.ac.uk:5000/orderly:master
+FROM docker.montagu.dide.ic.ac.uk:5000/orderly:i1800
 
 RUN apt-get update || apt-get update && apt-get install -y \
   libcurl4-openssl-dev


### PR DESCRIPTION
First merge https://github.com/vimc/orderly/pull/18 then repoint this back at the *hash* of the merge commit, then merge