### PR TITLE
i2517: Better behaviour with report timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ r_packages:
   - covr
 before_script:
   - R CMD INSTALL .
+after_success:
+  - Rscript -e 'covr::codecov()'
 
 r_github_packages:
   - vimc/orderly

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly.server
 Title: Serve Orderly
-Version: 0.1.1
+Version: 0.1.2
 Description: Run orderly reports as a server.
 License: MIT + file LICENSE
 Author: Rich FitzJohn

--- a/R/server.R
+++ b/R/server.R
@@ -116,8 +116,10 @@ server_endpoints <- function(runner) {
   ## NOTE: this ends up being exposed as a 'run' endpoint not a
   ## 'queue' endpoint because in the underlying runner queue/poll are
   ## separated but within the server both happen.
-  run <- function(name, parameters = NULL, ref = NULL, update = TRUE) {
-    key <- runner$queue(name, parameters, ref, as_logical(update))
+  run <- function(name, parameters = NULL, ref = NULL, update = TRUE,
+                  timeout = NULL) {
+    key <- runner$queue(name, parameters, ref, as_logical(update),
+                        timeout = as_integer(timeout, 600))
     list(name = name,
          key = key,
          path = sprintf("/v1/reports/%s/status/", key))
@@ -187,7 +189,7 @@ server_endpoints <- function(runner) {
               list(name   = "run",
                    dest   = run,
                    path   = "/v1/reports/:name/run/",
-                   query  = c("parameters", "ref", "update"),
+                   query  = c("parameters", "ref", "update", "timeout"),
                    post   = "parameters",
                    method = "POST"),
               list(name   = "status",

--- a/R/util.R
+++ b/R/util.R
@@ -9,6 +9,19 @@ as_logical <- function(x, name = deparse(substitute(x))) {
          stop(sprintf("Invalid input for '%s'", name)))
 }
 
+as_integer <- function(x, default, name = deparse(substitute(x))) {
+  if (is.null(x)) {
+    default
+  } else {
+    ok <- is.character(x) && length(x) == 1L && !is.na(x) &&
+      grepl("^[0-9]+$", x)
+    if (!ok) {
+      stop(sprintf("Invalid input for '%s'", name))
+    }
+    as.integer(x)
+  }
+}
+
 to_json <- function(x, ...) {
   jsonlite::toJSON(x, auto_unbox = TRUE, ...)
 }

--- a/tests/testthat/helper-orderly.server.R
+++ b/tests/testthat/helper-orderly.server.R
@@ -23,7 +23,7 @@ wait_for_process_termination <- function(process, ...) {
 wait_for_finished <- function(key, server, ...) {
   is_running <- function() {
     r <- httr::GET(server$api_url("/v1/reports/%s/status/", key))
-    !(content(r)$data$status %in% c("success", "error"))
+    !(content(r)$data$status %in% c("success", "error", "killed"))
   }
   wait_while(is_running, ...)
 }

--- a/tests/testthat/test-orderly-server.R
+++ b/tests/testthat/test-orderly-server.R
@@ -212,7 +212,7 @@ test_that("run report honours timeout", {
   expect_equal(st$data$status, "killed")
 
   r <- httr::POST(server$api_url("/v1/reports/count/run/"),
-                  query = list(timeout = 3))
+                  query = list(timeout = 60))
   expect_equal(httr::status_code(r), 200)
   dat <- content(r)
   wait_for_finished(dat$data$key, server)

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -1,0 +1,14 @@
+context("util")
+
+test_that("as_integer", {
+  expect_identical(as_integer("1"), 1L)
+  expect_identical(as_integer("100"), 100L)
+  expect_identical(as_integer(NULL, 500L), 500L)
+
+  x <- 100
+  expect_error(as_integer(x), "Invalid input for 'x'")
+  expect_error(as_integer(NA_character_), "Invalid input for")
+  expect_error(as_integer(c("1", "2")), "Invalid input for")
+  expect_error(as_integer("-1"), "Invalid input for")
+  expect_error(as_integer("1.23"), "Invalid input for")
+})


### PR DESCRIPTION
Add the `timeout` parameter to accepted query parameters for the endpoint

See also: https://github.com/vimc/orderly/pull/82 and https://github.com/vimc/montagu-r/pull/20