### PR TITLE
VIMC-3144

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ after_success:
   - Rscript -e 'covr::codecov()'
 
 r_github_packages:
-  - vimc/orderly
+  - vimc/orderly@vimc-2469
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ after_success:
   - Rscript -e 'covr::codecov()'
 
 r_github_packages:
-  - vimc/orderly@vimc-2469
+  - vimc/orderly
 
 addons:
   apt:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Imports:
     R6,
     httpuv,
     jsonlite,
-    optparse,
+    docopt,
     orderly (>= 0.7.14),
     processx,
     webutils

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Imports:
     httpuv,
     jsonlite,
     optparse,
-    orderly (>= 0.7.0),
+    orderly (>= 0.7.14),
     processx,
     webutils
 Suggests:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly.server
 Title: Serve Orderly
-Version: 0.1.3
+Version: 0.1.4
 Description: Run orderly reports as a server.
 License: MIT + file LICENSE
 Author: Rich FitzJohn

--- a/R/main.R
+++ b/R/main.R
@@ -4,36 +4,21 @@ main <- function(args = commandArgs(TRUE)) {
 }
 
 main_args <- function(args) {
-  opts <- list(
-    optparse::make_option("--port",
-                          help = "Port to run on",
-                          type = "integer",
-                          default = "8321"),
-    optparse::make_option("--host",
-                          help = "IP address owned by this server",
-                          default = "0.0.0.0",
-                          type = "character"),
-    optparse::make_option("--no-ref",
-                          help = "Prevent git reference switching",
-                          type = "logical",
-                          default = FALSE,
-                          action = "store_true",
-                          dest = "no_ref"),
-    optparse::make_option("--go-signal",
-                          help = "Path for go signal (within path)",
-                          default = NULL,
-                          type = "character",
-                          dest = "go_signal"))
-  parser <- optparse::OptionParser(
-    option_list = opts,
-    usage = "%prog [options] <path>")
-  res <- optparse::parse_args(parser, args, positional_arguments = 1L)
+  doc <- "Usage:
+  orderly.server [options] <path>
 
-  list(path = res$args[[1L]],
-       port = res$options$port,
-       host = res$options$host,
-       allow_ref = !res$options$no_ref,
-       go_signal = res$options$go_signal)
+Options:
+  --port=PORT       Port to run on [default: 8321]
+  --host=HOST       IP address owned by this server [default: 0.0.0.0]
+  --no-ref          Prevent git reference switching
+  --go-signal=PATH  Relative path for go signal"
+  res <- docopt::docopt(doc, args)
+
+  list(path = res[["path"]],
+       port = as_integer(res[["port"]]),
+       host = res[["host"]],
+       allow_ref = !res[["no-ref"]],
+       go_signal = res[["go-signal"]])
 }
 
 write_script <- function(path) {

--- a/R/server.R
+++ b/R/server.R
@@ -118,6 +118,7 @@ server_endpoints <- function(runner) {
   ## separated but within the server both happen.
   run <- function(name, parameters = NULL, ref = NULL, update = TRUE,
                   timeout = NULL) {
+    parameters <- as_orderly_parameter_list(parameters)
     key <- runner$queue(name, parameters, ref, as_logical(update),
                         timeout = as_integer(timeout, 600))
     list(name = name,

--- a/R/util.R
+++ b/R/util.R
@@ -47,3 +47,17 @@ wait_while <- function(continue, timeout = 10, poll = 0.02) {
     }
   }
 }
+
+
+## Convert a json array of parameters into the format expected by
+## orderly >= 0.7.14
+as_orderly_parameter_list <- function(x) {
+  if (is.null(x) || is.na(x)) {
+    return(NULL)
+  }
+  x <- jsonlite::fromJSON(x, FALSE)
+  if (length(x) == 0) {
+    return(NULL)
+  }
+  sprintf("%s=%s", names(x), vapply(x, as.character, ""))
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.montagu.dide.ic.ac.uk:5000/orderly:21a5b01
+FROM docker.montagu.dide.ic.ac.uk:5000/orderly:vimc-2469
 
 RUN apt-get update || apt-get update && apt-get install -y \
   libcurl4-openssl-dev

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.montagu.dide.ic.ac.uk:5000/orderly:b93c940
+FROM docker.montagu.dide.ic.ac.uk:5000/orderly:f99616d
 
 RUN apt-get update || apt-get update && apt-get install -y \
   libcurl4-openssl-dev

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.montagu.dide.ic.ac.uk:5000/orderly:vimc-2469
+FROM docker.montagu.dide.ic.ac.uk:5000/orderly:b93c940
 
 RUN apt-get update || apt-get update && apt-get install -y \
   libcurl4-openssl-dev

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -1,0 +1,50 @@
+context("main")
+
+test_that("defaults", {
+  expect_equal(
+    main_args("path"),
+    list(path = "path", port = 8321, host = "0.0.0.0", allow_ref = TRUE,
+         go_signal = NULL))
+})
+
+
+test_that("set port", {
+  expect_equal(
+    main_args(c("path", "--port", "8888")),
+    list(path = "path", port = 8888, host = "0.0.0.0", allow_ref = TRUE,
+         go_signal = NULL))
+})
+
+
+test_that("set host", {
+  expect_equal(
+    main_args(c("path", "--host", "127.0.0.1")),
+    list(path = "path", port = 8321, host = "127.0.0.1", allow_ref = TRUE,
+         go_signal = NULL))
+})
+
+
+test_that("prevent reference switch", {
+  expect_equal(
+    main_args(c("path", "--no-ref")),
+    list(path = "path", port = 8321, host = "0.0.0.0", allow_ref = FALSE,
+         go_signal = NULL))
+})
+
+
+test_that("Set go signal", {
+  expect_equal(
+    main_args(c("path", "--go-signal", "somewhere")),
+    list(path = "path", port = 8321, host = "0.0.0.0", allow_ref = TRUE,
+         go_signal = "somewhere"))
+})
+
+
+test_that("write script", {
+  p <- tempfile()
+  expect_error(write_script(p), "'path' must be a directory")
+  dir.create(p)
+  res <- write_script(p)
+  expect_equal(basename(res), "orderly.server")
+  expect_true(file.exists(res))
+})

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -12,3 +12,13 @@ test_that("as_integer", {
   expect_error(as_integer("-1"), "Invalid input for")
   expect_error(as_integer("1.23"), "Invalid input for")
 })
+
+
+test_that("as_orderly_parameter_list", {
+  expect_null(as_orderly_parameter_list(NA))
+  expect_null(as_orderly_parameter_list(NULL))
+  expect_null(as_orderly_parameter_list("{}"))
+  expect_equal(as_orderly_parameter_list('{"a":1}'), "a=1")
+  expect_equal(as_orderly_parameter_list('{"a":"foo"}'), "a=foo")
+  expect_equal(as_orderly_parameter_list('{"a":1,"b":2}'), c("a=1", "b=2"))
+})


### PR DESCRIPTION
This PR will update ordery.server to use new parameter passing format expected by orderly following https://github.com/vimc/orderly/pull/128 - once that pr is merged, the links to vimc-2469 in the travis.yml and the Dockerfile should be updated before merging.

There is an opportunistic port to docopt (from optparse) here too.  We never actually had testing on the cli but that was added before the refactor (
124b05b, then 93d3118)