### PR TITLE
vimc-3638: orderly.server correctly handles parameters

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly.server
 Title: Serve Orderly
-Version: 0.1.4
+Version: 0.1.5
 Description: Run orderly reports as a server.
 License: MIT + file LICENSE
 Author: Rich FitzJohn

--- a/R/server.R
+++ b/R/server.R
@@ -118,7 +118,6 @@ server_endpoints <- function(runner) {
   ## separated but within the server both happen.
   run <- function(name, parameters = NULL, ref = NULL, update = TRUE,
                   timeout = NULL) {
-    parameters <- as_orderly_parameter_list(parameters)
     key <- runner$queue(name, parameters, ref, as_logical(update),
                         timeout = as_integer(timeout, 600))
     list(name = name,

--- a/R/util.R
+++ b/R/util.R
@@ -59,5 +59,6 @@ as_orderly_parameter_list <- function(x) {
   if (length(x) == 0) {
     return(NULL)
   }
-  sprintf("%s=%s", names(x), vapply(x, as.character, ""))
+  paste(sprintf("%s=%s", names(x), vapply(x, as.character, "")),
+        collapse = " ")
 }

--- a/R/util.R
+++ b/R/util.R
@@ -47,18 +47,3 @@ wait_while <- function(continue, timeout = 10, poll = 0.02) {
     }
   }
 }
-
-
-## Convert a json array of parameters into the format expected by
-## orderly >= 0.7.14
-as_orderly_parameter_list <- function(x) {
-  if (is.null(x) || is.na(x)) {
-    return(NULL)
-  }
-  x <- jsonlite::fromJSON(x, FALSE)
-  if (length(x) == 0) {
-    return(NULL)
-  }
-  paste(sprintf("%s=%s", names(x), vapply(x, as.character, "")),
-        collapse = " ")
-}

--- a/tests/testthat/test-orderly-server.R
+++ b/tests/testthat/test-orderly-server.R
@@ -56,7 +56,8 @@ test_that("run", {
   server <- start_test_server()
   on.exit(server$stop())
 
-  r <- httr::POST(server$api_url("/v1/reports/example/run/"))
+  r <- httr::POST(server$api_url("/v1/reports/example/run/"),
+                  body = NULL, encode = "json")
   expect_equal(httr::status_code(r), 200)
   dat <- content(r)
   expect_equal(dat$status, "success")

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -12,13 +12,3 @@ test_that("as_integer", {
   expect_error(as_integer("-1"), "Invalid input for")
   expect_error(as_integer("1.23"), "Invalid input for")
 })
-
-
-test_that("as_orderly_parameter_list", {
-  expect_null(as_orderly_parameter_list(NA))
-  expect_null(as_orderly_parameter_list(NULL))
-  expect_null(as_orderly_parameter_list("{}"))
-  expect_equal(as_orderly_parameter_list('{"a":1}'), "a=1")
-  expect_equal(as_orderly_parameter_list('{"a":"foo"}'), "a=foo")
-  expect_equal(as_orderly_parameter_list('{"a":1,"b":2}'), c("a=1", "b=2"))
-})

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -12,3 +12,29 @@ test_that("as_integer", {
   expect_error(as_integer("-1"), "Invalid input for")
   expect_error(as_integer("1.23"), "Invalid input for")
 })
+
+
+test_that("is_directory", {
+  path <- tempfile()
+  expect_false(is_directory(path))
+  file.create(path)
+  expect_false(is_directory(path))
+  expect_true(is_directory(tempdir()))
+})
+
+
+test_that("time_diff_secs", {
+  t <- Sys.time()
+  expect_equal(time_diff_secs(t, t - 5), 5)
+  expect_equal(time_diff_secs(t, t - 500), 500)
+  expect_equal(time_diff_secs(t, t - 50000), 50000)
+})
+
+
+test_that("wait_while", {
+  expect_null(wait_while(function() FALSE, 0, 0))
+  expect_error(wait_while(function() TRUE, 0, 0),
+               "Timeout reached")
+  expect_error(wait_while(function() TRUE, 0.05, 0.01),
+               "Timeout reached")
+})


### PR DESCRIPTION
Required for VIMC-3575 as requested by @susyelo last Monday, see companion pull request in orderlyweb.

This PR fixes the handling of parameters in orderly.server and adds a test of this.  Mostly this is reverting changes made in f77d63b (#14) some of which we might pick up again when porting this package to use pkgapi.

Because I removed a helper, the coverage check failed so I did some basic testing of functions in util.R - these are separate to the functional changes 😀 