### PR TITLE
vimc-3642: Install openssh-client for ssh-keyscan

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,8 @@
 FROM vimc/orderly:master
 
 RUN apt-get update || apt-get update && apt-get install -y \
-  libcurl4-openssl-dev
+  libcurl4-openssl-dev \
+  openssh-client
 
 # processx is an orderly Suggests that we require for the server.
 RUN install2.r --error \


### PR DESCRIPTION
Looks like ssh-keyscan has disappeared from either the r-ver image or one of the dependencies we dragged in (possibly because we added --no-install-recommends actually) but this breaks the deploy completely!