### PR TITLE
VIMC-3860: Add run metadata endpoint

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,4 +12,4 @@
 ^spec$
 ^buildkite$
 ^\.lintr$
-^\.hadoloint$
+^\.hadolint$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,4 +12,4 @@
 ^spec$
 ^buildkite$
 ^\.lintr$
-^\.hadolint$
+^\.hadolint\.yaml$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,9 +17,9 @@ Imports:
 Suggests:
     httr,
     jsonvalidate (>= 1.2.2),
-    mockery,
+    mockery,    
     sys,
     testthat,
-    utils
+    withr
 RoxygenNote: 7.0.2
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ Suggests:
     jsonvalidate (>= 1.2.2),
     mockery,
     sys,
-    testthat
+    testthat,
+    utils
 RoxygenNote: 7.0.2
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly.server
 Title: Serve Orderly
-Version: 0.2.0
+Version: 0.2.1
 Description: Run orderly reports as a server.
 License: MIT + file LICENSE
 Author: Rich FitzJohn

--- a/R/api.R
+++ b/R/api.R
@@ -31,7 +31,7 @@ returning_json <- function(schema) {
 ## For compatibility only
 target_index <- function() {
   list(name = scalar("orderly.server"),
-       version = scalar(as.character(packageVersion("orderly.server"))),
+       version = scalar(as.character(utils::packageVersion("orderly.server"))),
        endpoints = c(
          "/",
          "/v1/reports/:key/kill/",

--- a/R/api.R
+++ b/R/api.R
@@ -161,12 +161,21 @@ target_run_metadata <- function(runner) {
   if (length(changelog) > 0) {
     changelog <- vcapply(changelog, scalar, USE.NAMES = FALSE)
   }
-  instances <- names(runner$config$database$source$instances)
-  if (length(instances) > 0) {
-    vcapply(instances, scalar, USE.NAMES = FALSE)
+
+  databases <- names(runner$config$database)
+  instances <- NULL
+  if (length(databases) > 0) {
+    instances <- lapply(databases, function(db) {
+      instances <- names(runner$config$database[[db]]$instances)
+      instances <- instances %||% c()
+      vcapply(instances, scalar, USE.NAMES = FALSE)
+    })
+    names(instances) <- databases
   }
+
   list(
-    instances_supported = scalar(length(instances) > 0),
+    name = scalar(runner$config$server_options()$name),
+    instances_supported = scalar(any(viapply(instances, length) > 0)),
     git_supported = scalar(isTRUE(runner$has_git)),
     instances = instances,
     changelog_types = changelog

--- a/R/util.R
+++ b/R/util.R
@@ -29,3 +29,7 @@ scalar <- function(x) {
 vcapply <- function(X, FUN, ...) { # nolint
   vapply(X, FUN, character(1), ...)
 }
+
+viapply <- function(X, FUN, ...) { # nolint
+  vapply(X, FUN, integer(1), ...)
+}

--- a/R/util.R
+++ b/R/util.R
@@ -25,3 +25,7 @@ wait_while <- function(continue, timeout = 10, poll = 0.02) {
 scalar <- function(x) {
   jsonlite::unbox(x)
 }
+
+vcapply <- function(X, FUN, ...) { # nolint
+  vapply(X, FUN, character(1), ...)
+}

--- a/inst/schema/RunMetadata.schema.json
+++ b/inst/schema/RunMetadata.schema.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "RunMetadata",
+    "type": "object",
+    "properties": {
+        "instances_supported": {
+            "type": "boolean"
+        },
+        "git_supported": {
+            "type": "boolean"
+        },
+        "instances": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "changelog_types": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+   },
+    "required": ["instances_supported", "git_supported", "instances",
+                 "changelog_types"],
+    "additionalProperties": false
+}

--- a/inst/schema/RunMetadata.schema.json
+++ b/inst/schema/RunMetadata.schema.json
@@ -3,6 +3,9 @@
     "id": "RunMetadata",
     "type": "object",
     "properties": {
+        "name": {
+            "type": [ "string", "null" ]
+        },
         "instances_supported": {
             "type": "boolean"
         },
@@ -10,9 +13,12 @@
             "type": "boolean"
         },
         "instances": {
-            "type": "array",
-            "items": {
-                "type": "string"
+            "type": "object",
+            "additionalProperties": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
             }
         },
         "changelog_types": {
@@ -22,7 +28,7 @@
             }
         }
    },
-    "required": ["instances_supported", "git_supported", "instances",
+    "required": ["name", "instances_supported", "git_supported", "instances",
                  "changelog_types"],
     "additionalProperties": false
 }

--- a/tests/testthat/helper-orderly.server.R
+++ b/tests/testthat/helper-orderly.server.R
@@ -86,7 +86,8 @@ read_json <- function(path, ...) {
 
 ## There is going to be some work here to keep these up-to-date:
 mock_runner <- function(keys = NULL, status = NULL, git_status = NULL,
-                        git_fetch = NULL, git_pull = NULL) {
+                        git_fetch = NULL, git_pull = NULL, config = NULL,
+                        has_git = TRUE) {
   list(
     rebuild = mockery::mock(TRUE, cycle = TRUE),
     queue = mockery::mock(keys, cycle = TRUE),
@@ -94,7 +95,9 @@ mock_runner <- function(keys = NULL, status = NULL, git_status = NULL,
     kill = mockery::mock(TRUE, cycle = TRUE),
     git_status = mockery::mock(git_status, cycle = TRUE),
     git_fetch = mockery::mock(git_fetch, cycle = TRUE),
-    git_pull = mockery::mock(git_pull, cycle = TRUE))
+    git_pull = mockery::mock(git_pull, cycle = TRUE),
+    config = config,
+    has_git = has_git)
 }
 
 

--- a/tests/testthat/helper-orderly.server.R
+++ b/tests/testthat/helper-orderly.server.R
@@ -65,7 +65,7 @@ test_runner2 <- function(path = tempfile()) {
 
 expect_valid_json <- function(json, schema) {
   testthat::skip_if_not_installed("jsonvalidate")
-  if (packageVersion("jsonvalidate") <= "1.1.0") {
+  if (utils::packageVersion("jsonvalidate") <= "1.1.0") {
     valid <- jsonvalidate::json_validate(json, schema)
   } else {
     valid <- jsonvalidate::json_validate(json, schema, engine = "ajv")

--- a/tests/testthat/helper-orderly.server.R
+++ b/tests/testthat/helper-orderly.server.R
@@ -125,3 +125,7 @@ orderly_git_ref_to_sha <- orderly:::git_ref_to_sha
 orderly_git_ref_exists <- orderly:::git_ref_exists
 orderly_git_run <- orderly:::git_run
 ## nolint end
+
+version_info <- function() {
+  scalar(as.character(utils::packageVersion("orderly.server")))
+}

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -5,7 +5,7 @@ test_that("index", {
 
   res <- endpoint$target()
   expect_equal(res$name, scalar("orderly.server"))
-  expect_equal(res$version, scalar("0.2.1"))
+  expect_equal(res$version, version_info())
   expect_true("/v1/reports/:key/status/" %in% res$endpoints)
 
   runner <- mock_runner()

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -5,7 +5,7 @@ test_that("index", {
 
   res <- endpoint$target()
   expect_equal(res$name, scalar("orderly.server"))
-  expect_equal(res$version, scalar("0.2.0"))
+  expect_equal(res$version, scalar("0.2.1"))
   expect_true("/v1/reports/:key/status/" %in% res$endpoints)
 
   runner <- mock_runner()

--- a/tests/testthat/test-z-integration.R
+++ b/tests/testthat/test-z-integration.R
@@ -237,3 +237,20 @@ test_that("pass parameters", {
   expect_match(st$data$output$stderr, "time: 1", fixed = TRUE, all = FALSE)
   expect_match(st$data$output$stderr, "poll: 0.1", fixed = TRUE, all = FALSE)
 })
+
+test_that("run-metadata", {
+  path <- orderly_prepare_orderly_git_example()
+  server <- start_test_server(path[["local"]])
+  on.exit(server$stop())
+
+  r <- content(httr::GET(server$api_url("/run-metadata")))
+
+  expect_equal(r$status, "success")
+  expect_null(r$errors)
+  expect_equal(names(r$data), c("instances_supported", "git_supported",
+                                "instances", "changelog_types"))
+  expect_false(r$data$instances_supported)
+  expect_true(r$data$git_supported)
+  expect_null(r$data$instances)
+  expect_equal(r$data$changelog_types, c(scalar("public")))
+})

--- a/tests/testthat/test-z-integration.R
+++ b/tests/testthat/test-z-integration.R
@@ -247,10 +247,11 @@ test_that("run-metadata", {
 
   expect_equal(r$status, "success")
   expect_null(r$errors)
-  expect_equal(names(r$data), c("instances_supported", "git_supported",
+  expect_equal(names(r$data), c("name", "instances_supported", "git_supported",
                                 "instances", "changelog_types"))
+  expect_null(r$data$name)
   expect_false(r$data$instances_supported)
   expect_true(r$data$git_supported)
-  expect_null(r$data$instances)
+  expect_equal(r$data$instances, list(source = list()))
   expect_equal(r$data$changelog_types, c(scalar("public")))
 })


### PR DESCRIPTION
This creates an endpoint `GET` at `/run-metadata` which returns data like
```
{
    "name": "production",
    "instances_supported": true,
    "git_supported": true,
    "instances": ["production", "science"],
    "changelog_types": ["internal", "published"]
}
```

Showing the diff compared to `vimc-3913` base