### PR TITLE
Fix arg name issues after docopt change

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Imports:
     httpuv,
     jsonlite,
     DBI,
-    docopt,
+    docopt (>= 0.7.1),
     orderly (>= 1.2.12),
     pkgapi (>= 0.0.7),
     processx,

--- a/R/main.R
+++ b/R/main.R
@@ -17,8 +17,8 @@ Options:
   list(path = res[["path"]],
        port = as.integer(res[["port"]]),
        host = res[["host"]],
-       allow_ref = !res[["no-ref"]],
-       go_signal = res[["go-signal"]])
+       allow_ref = !res[["no_ref"]],
+       go_signal = res[["go_signal"]])
 }
 
 write_script <- function(path, code, versioned = FALSE) {


### PR DESCRIPTION
This fixes bug saw when trying to run up orderly server

```
docker run -v /demo:/orderly vimc/orderly.server:master /orderly`
Error in !res[["no-ref"]] : invalid argument typeCalls: <Anonymous> -> main_args
Execution halted
```

This is due to docopt change now automatically maps `kebab-case` to `snake_case`.

Confirmed the updated image gets past that stage when running locally.

The weird thing is there are tests for this in `test-main.R` which fail locally for me now. But didn't when we made the most recent change. Any idea why that might happen? Were we getting different versions of the package at different times for some reason? Kind of weird. I've pinned the docopt version to the most recent one for now too.