### PR TITLE
Make docopt usage robust to changes and add a basic test server can be brought up

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -12,13 +12,19 @@ Options:
   --host=HOST       IP address owned by this server [default: 0.0.0.0]
   --no-ref          Prevent git reference switching
   --go-signal=PATH  Relative path for go signal"
-  res <- docopt::docopt(doc, args)
+  res <- docopt_parse(doc, args)
 
   list(path = res[["path"]],
        port = as.integer(res[["port"]]),
        host = res[["host"]],
        allow_ref = !res[["no_ref"]],
        go_signal = res[["go_signal"]])
+}
+
+docopt_parse <- function(doc, args) {
+  dat <- docopt::docopt(doc, args)
+  names(dat) <- gsub("-", "_", names(dat), fixed = TRUE)
+  dat
 }
 
 write_script <- function(path, code, versioned = FALSE) {

--- a/buildkite/pipeline.yml
+++ b/buildkite/pipeline.yml
@@ -4,6 +4,9 @@ steps:
 
   - wait
 
+  - label: ":hammer: Test"
+    command: docker/test
+
   - label: ":shipit: Push"
     command: docker/push
 

--- a/docker/test
+++ b/docker/test
@@ -17,7 +17,6 @@ rm -rf orderly-demo
 git clone https://github.com/vimc/orderly-demo
 mkdir -p orderly-demo/runner/log
 mkdir -p orderly-demo/runner/id
-Rscript -e 'setwd("orderly-demo")' -e 'orderly::orderly_rebuild()'
 
 docker run --rm -d \
     -p 8321:8321 \

--- a/docker/test
+++ b/docker/test
@@ -15,6 +15,8 @@ trap cleanup EXIT
 
 rm -rf orderly-demo
 git clone https://github.com/vimc/orderly-demo
+mkdir -p orderly-demo/runner/log
+mkdir -p orderly-demo/runner/id
 Rscript -e 'setwd("orderly-demo")' -e 'orderly::orderly_rebuild()'
 
 docker run --rm -d \

--- a/docker/test
+++ b/docker/test
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -ex
+HERE=$(dirname $0)
+. $HERE/common
+
+NAME_SERVER=orderly_server
+
+function cleanup {
+  echo "Cleaning up"
+  docker kill $NAME_SERVER > /dev/null || true
+  rm -rf $PACKAGE_ROOT/orderly-demo
+}
+
+trap cleanup EXIT
+
+rm -rf orderly-demo
+git clone https://github.com/vimc/orderly-demo
+Rscript -e 'setwd("orderly-demo")' -e 'orderly::orderly_rebuild()'
+
+docker run --rm -d \
+    -p 8321:8321 \
+    --mount type=bind,src=$PACKAGE_ROOT/orderly-demo,dst=/demo \
+    --name $NAME_SERVER $TAG_SHA demo
+
+
+for attempt in $(seq 10); do
+    echo "Attempt $attempt"
+    ## Sleep first here as otherwise receive an error
+    ## curl: (56) Recv failure: Connection reset by peer
+    ## which exists instantly
+    sleep 2
+    RESPONSE=$(curl --silent --write-out "%{http_code}\n" --output /dev/null \
+               http://localhost:8321)
+    if [ "$RESPONSE" == "200" ]; then
+        echo "SUCCESS"
+        exit 0
+    fi
+done
+
+echo "FAIL"
+exit 1


### PR DESCRIPTION
This PR will
* Make docopt usage robust around it either keeping kebab-cased vars or automatically converting them to snake_case
* Add a test step to the buildkite build to check that the server can be started