### PR TITLE
Return remote info info in run-metadata endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,4 @@ addons:
     packages:
       - libv8-dev
       - libapparmor-dev
+      - libsodium-dev

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly.server
 Title: Serve Orderly
-Version: 0.2.4
+Version: 0.2.5
 Description: Run orderly reports as a server.
 License: MIT + file LICENSE
 Author: Rich FitzJohn

--- a/R/api.R
+++ b/R/api.R
@@ -200,11 +200,17 @@ target_run_metadata <- function(runner) {
     names(instances) <- databases
   }
 
+  remotes <- names(runner$config$remote)
+  if (length(remotes) > 0) {
+    remotes <- vcapply(remotes, scalar, USE.NAMES = FALSE)
+  }
+
   list(
     name = scalar(runner$config$server_options()$name),
     instances_supported = scalar(any(viapply(instances, length) > 0)),
     git_supported = scalar(isTRUE(runner$has_git)),
     instances = instances,
+    remotes = remotes,
     changelog_types = changelog
   )
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,9 +10,14 @@ RUN install2.r --error \
   --repos https://cloud.r-project.org \
   --repos https://vimc.github.io/drat \
   jsonlite \
-  pkgapi \
   processx \
   webutils
+
+COPY docker/bin /usr/local/bin/
+
+RUN install_remote \
+        reside-ic/pkgapi \
+        ropensci/jsonvalidate
 
 COPY . /orderly.server
 RUN R CMD INSTALL /orderly.server && \

--- a/docker/bin/install_remote
+++ b/docker/bin/install_remote
@@ -1,0 +1,9 @@
+#!/usr/bin/env Rscript
+'Usage:
+install_remote [--repos=REPO...] <spec>...' -> usage
+opts <- docopt::docopt(usage)
+
+options(repos = c(opts$repos, getOption("repos")))
+spec <- opts$spec
+
+remotes::install_github(spec)

--- a/docker/test
+++ b/docker/test
@@ -23,6 +23,10 @@ docker run --rm -d \
     --mount type=bind,src=$PACKAGE_ROOT/orderly-demo,dst=/demo \
     --name $NAME_SERVER $TAG_SHA demo
 
+## Sleep first here as otherwise receive an error
+## curl: (56) Recv failure: Connection reset by peer
+## which exists instantly
+sleep 2
 
 for attempt in $(seq 10); do
     echo "Attempt $attempt"

--- a/inst/schema/RunMetadata.schema.json
+++ b/inst/schema/RunMetadata.schema.json
@@ -21,6 +21,12 @@
                 }
             }
         },
+        "remotes": {
+            "type": [ "array", "null" ],
+            "items": {
+                "type": "string"
+            }
+        },
         "changelog_types": {
             "type": "array",
             "items": {
@@ -29,6 +35,6 @@
         }
    },
     "required": ["name", "instances_supported", "git_supported", "instances",
-                 "changelog_types"],
+                 "remotes", "changelog_types"],
     "additionalProperties": false
 }

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -402,6 +402,7 @@ test_that("run-metadata pulls information from runner", {
     instances = list(
       "source" = character(0)
     ),
+    remotes = NULL,
     changelog_types = NULL
   ))
 
@@ -437,6 +438,7 @@ test_that("run-metadata pulls information from runner", {
     instances = list(
       "source" = c(scalar("production"), scalar("staging"))
     ),
+    remotes = NULL,
     changelog_types = c(scalar("external"))
   ))
 })
@@ -477,6 +479,7 @@ test_that("run-metadata can get config for multiple databases", {
       source = c(scalar("production"), scalar("staging")),
       annex = character(0)
     ),
+    remotes = NULL,
     changelog_types = NULL
   ))
 
@@ -521,6 +524,7 @@ test_that("run-metadata can get config for multiple databases", {
       source = c(scalar("production"), scalar("staging")),
       annex = c(scalar("annex1"), scalar("annex2"))
     ),
+    remotes = NULL,
     changelog_types = NULL
   ))
 })
@@ -574,6 +578,7 @@ test_that("run metadata can get name from config", {
     instances = list(
       source = c(scalar("production"), scalar("staging"))
     ),
+    remotes = c(scalar("production"), scalar("staging")),
     changelog_types = NULL
   ))
 })

--- a/tests/testthat/test-z-integration.R
+++ b/tests/testthat/test-z-integration.R
@@ -248,11 +248,12 @@ test_that("run-metadata", {
   expect_equal(r$status, "success")
   expect_null(r$errors)
   expect_equal(names(r$data), c("name", "instances_supported", "git_supported",
-                                "instances", "changelog_types"))
+                                "instances", "remotes", "changelog_types"))
   expect_null(r$data$name)
   expect_false(r$data$instances_supported)
   expect_true(r$data$git_supported)
   expect_equal(r$data$instances, list(source = list()))
+  expect_equal(r$data$remotes, NULL)
   expect_equal(r$data$changelog_types, c(scalar("public")))
 })
 


### PR DESCRIPTION
This PR will
* Include remote info as `remotes` section in `run-metadata` response

This is the remote where dependencies should be resolved from when running a report.


I think if running on production then users probably shouldn't be able to resolve dependencies from science but I don't know where that logic belongs (presumably in same place as we have the logic that says if production then don't allow choosing git branch)

