### PR TITLE
VIMC-4376: Support for bundles via the orderly.server

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly.server
 Title: Serve Orderly
-Version: 0.2.4
+Version: 0.2.5
 Description: Run orderly reports as a server.
 License: MIT + file LICENSE
 Author: Rich FitzJohn

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,8 @@ Imports:
     pkgapi (>= 0.0.7),
     processx,
     webutils,
-    yaml
+    yaml,
+    zip
 Suggests:
     httr,
     jsonvalidate (>= 1.2.2),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Imports:
     jsonlite,
     DBI,
     docopt (>= 0.7.1),
-    orderly (>= 1.2.12),
+    orderly (>= 1.2.18),
     pkgapi (>= 0.0.7),
     processx,
     webutils,

--- a/R/api.R
+++ b/R/api.R
@@ -268,9 +268,12 @@ endpoint_report_parameters <- function(runner) {
   )
 }
 
-target_bundle_pack <- function(runner, name, parameters = NULL, ref = NULL,
-                                 instance = NULL, update = TRUE) {
-  path <- runner$bundle_pack(name, parameters, ref, instance, update)
+target_bundle_pack <- function(runner, name, parameters = NULL,
+                               instance = NULL) {
+  if (!is.null(parameters)) {
+    parameters <- jsonlite::fromJSON(parameters)
+  }
+  path <- runner$bundle_pack(name, parameters, instance)
   on.exit(unlink(path))
   bytes <- readBin(path, "raw", n = file.size(path))
   bytes <- pkgapi::pkgapi_add_headers(
@@ -281,9 +284,7 @@ target_bundle_pack <- function(runner, name, parameters = NULL, ref = NULL,
 endpoint_bundle_pack <- function(runner) {
   pkgapi::pkgapi_endpoint$new(
     "POST", "/v1/bundle/pack/<name>", target_bundle_pack,
-    pkgapi::pkgapi_input_query(ref = "string",
-                               instance = "string",
-                               update = "logical"),
+    pkgapi::pkgapi_input_query(instance = "string"),
     pkgapi::pkgapi_input_body_json("parameters", "Parameters.schema",
                                    schema_root()),
     pkgapi::pkgapi_state(runner = runner),

--- a/R/api.R
+++ b/R/api.R
@@ -303,7 +303,8 @@ endpoint_bundle_import <- function(runner, data) {
   pkgapi::pkgapi_endpoint$new(
     "POST", "/v1/bundle/import", target_bundle_import,
     ## NOTE: This is not ideal because it requires
-    ## application/octet-stream - see RESIDE-208 for details.
+    ## application/octet-stream - see RESIDE-208 for details, can be
+    ## updated once we move to porcelain >= 0.1.1
     pkgapi::pkgapi_input_body_binary("data"),
     pkgapi::pkgapi_state(runner = runner),
     returning = returning_json("BundleImport.schema"))

--- a/R/runner.R
+++ b/R/runner.R
@@ -231,14 +231,7 @@ orderly_runner_ <- R6::R6Class(
                                data = data, failed_only = failed_only)
     },
 
-    bundle_pack = function(name, parameters = NULL, ref = NULL,
-                           instance = NULL, update = FALSE) {
-      ## NOTE: because the orderly::orderly_bundle_pack does not
-      ## support ref, we only do the minimum here and support
-      ## pull-before-pack.
-      if (update && self$has_git) {
-        self$git_pull()
-      }
+    bundle_pack = function(name, parameters = NULL, instance = NULL) {
       res <- orderly::orderly_bundle_pack(tempfile(), name, parameters,
                                           root = self$config,
                                           instance = instance)

--- a/R/runner.R
+++ b/R/runner.R
@@ -231,6 +231,24 @@ orderly_runner_ <- R6::R6Class(
                                data = data, failed_only = failed_only)
     },
 
+    bundle_pack = function(name, parameters = NULL, ref = NULL,
+                           instance = NULL, update = FALSE) {
+      ## NOTE: because the orderly::orderly_bundle_pack does not
+      ## support ref, we only do the minimum here and support
+      ## pull-before-pack.
+      if (update && self$has_git) {
+        self$git_pull()
+      }
+      res <- orderly::orderly_bundle_pack(tempfile(), name, parameters,
+                                          root = self$config,
+                                          instance = instance)
+      res$path
+    },
+
+    bundle_import = function(path) {
+      orderly::orderly_bundle_import(path, root = self$config)
+    },
+
     poll = function() {
       key <- self$process$key
       if (!is.null(self$process)) {

--- a/inst/schema/BundleImport.schema.json
+++ b/inst/schema/BundleImport.schema.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "boolean",
+}

--- a/tests/testthat/helper-orderly.server.R
+++ b/tests/testthat/helper-orderly.server.R
@@ -87,7 +87,8 @@ mock_runner <- function(keys = NULL, status = NULL, git_status = NULL,
                         git_fetch = NULL, git_pull = NULL,
                         git_branches_no_merged = NULL, git_commits = NULL,
                         config = NULL, has_git = TRUE, get_reports = NULL,
-                        get_report_parameters = NULL) {
+                        get_report_parameters = NULL,
+                        bundle_pack = NULL, bundle_import = NULL) {
   list(
     rebuild = mockery::mock(TRUE, cycle = TRUE),
     queue = mockery::mock(keys, cycle = TRUE),
@@ -102,7 +103,9 @@ mock_runner <- function(keys = NULL, status = NULL, git_status = NULL,
     config = config,
     has_git = has_git,
     get_reports = mockery::mock(get_reports, cycle = TRUE),
-    get_report_parameters = mockery::mock(get_report_parameters, cycle = TRUE))
+    get_report_parameters = mockery::mock(get_report_parameters, cycle = TRUE),
+    bundle_pack = mockery::mock(bundle_pack, cycle = TRUE),
+    bundle_import = mockery::mock(bundle_import, cycle = TRUE))
 }
 
 

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -685,3 +685,39 @@ test_that("report parameter endponits handles errors", {
   expect_equal(params$error$data[[1]]$detail, scalar(
     "Failed to parse parameters for report 'minimal' and commit '84hd82n'"))
 })
+
+
+test_that("bundle pack can pack basic bundle", {
+  tmp <- tempfile(fileext = ".zip")
+  writeBin(as.raw(0:255), tmp)
+
+  runner <- mock_runner(bundle_pack = tmp)
+
+  endpoint <- endpoint_bundle_pack(runner)
+  res <- endpoint$run("name")
+  expect_equal(
+    mockery::mock_args(runner$bundle_pack)[[1]],
+    list("name", NULL, NULL))
+
+  expect_equal(res$data, as.raw(0:255), check.attributes = FALSE)
+  expect_equal(res$headers, list("Content-Disposition" = basename(tmp)))
+  expect_equal(res$status_code, 200L)
+})
+
+
+test_that("bundle pack can pass parameters and instance", {
+  tmp <- tempfile(fileext = ".zip")
+  writeBin(as.raw(0:255), tmp)
+
+  runner <- mock_runner(bundle_pack = tmp)
+
+  endpoint <- endpoint_bundle_pack(runner)
+  res <- endpoint$run("name", parameters = '{"a": 1}', instance = "myinstance")
+  expect_equal(
+    mockery::mock_args(runner$bundle_pack)[[1]],
+    list("name", list(a = 1), "myinstance"))
+
+  expect_equal(res$data, as.raw(0:255), check.attributes = FALSE)
+  expect_equal(res$headers, list("Content-Disposition" = basename(tmp)))
+  expect_equal(res$status_code, 200L)
+})

--- a/tests/testthat/test-runner.R
+++ b/tests/testthat/test-runner.R
@@ -601,3 +601,19 @@ test_that("can get parameters list from runner", {
   params <- runner$get_report_parameters("other", other_commits$id)
   expect_equal(params, list(nmin = NULL))
 })
+
+
+test_that("Can create and run bundles from runner", {
+  testthat::skip_on_cran()
+  skip_on_windows()
+  path <- orderly_prepare_orderly_example("demo")
+  runner <- orderly_runner(path)
+  pars <- '{"nmin":0.5}'
+  path_pack <- runner$bundle_pack("other", parameters = list(nmin = 0.5))
+  expect_true(file.exists(path_pack))
+  res <- orderly::orderly_bundle_run(path_pack, echo = FALSE)
+  runner$bundle_import(res$path)
+  expect_equal(
+    orderly::orderly_list_archive(path),
+    data.frame(name = "other", id = res$id, stringsAsFactors = FALSE))
+})


### PR DESCRIPTION
This PR adds two new endpoints to orderly.server:

* `POST /v1/bundle/pack/<name>`
* `POST /v1/bundle/import`

which add support for creating and reimporting bundles from orderly. This will be used to run long-running tasks on a cluster.