### PR TITLE
VIMC-4480: return default git and instance info from endpoints

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -192,21 +192,28 @@ target_run_metadata <- function(runner) {
     changelog <- vcapply(changelog, scalar, USE.NAMES = FALSE)
   }
 
-  databases <- names(runner$config$database)
+  server_options <- runner$config$server_options()
   instances <- NULL
-  if (length(databases) > 0) {
-    instances <- lapply(databases, function(db) {
-      instances <- names(runner$config$database[[db]]$instances)
-      instances <- instances %||% c()
-      vcapply(instances, scalar, USE.NAMES = FALSE)
-    })
-    names(instances) <- databases
+  instances_supported <- FALSE
+  if (!isTRUE(server_options$primary)) {
+    databases <- names(runner$config$database)
+    if (length(databases) > 0) {
+      instances <- lapply(databases, function(db) {
+        instances <- names(runner$config$database[[db]]$instances)
+        instances <- instances %||% c()
+        vcapply(instances, scalar, USE.NAMES = FALSE)
+      })
+      names(instances) <- databases
+    }
+    instances_supported <- any(viapply(instances, length) > 0)
   }
+
+  git_supported <- !isTRUE(server_options$master_only) && isTRUE(runner$has_git)
 
   list(
     name = scalar(runner$config$server_options()$name),
-    instances_supported = scalar(any(viapply(instances, length) > 0)),
-    git_supported = scalar(isTRUE(runner$has_git)),
+    instances_supported = scalar(instances_supported),
+    git_supported = scalar(git_supported),
     instances = instances,
     changelog_types = changelog
   )

--- a/R/api.R
+++ b/R/api.R
@@ -200,7 +200,6 @@ target_run_metadata <- function(runner) {
     if (length(databases) > 0) {
       instances <- lapply(databases, function(db) {
         instances <- names(runner$config$database[[db]]$instances)
-        instances <- instances %||% c()
         vcapply(instances, scalar, USE.NAMES = FALSE)
       })
       names(instances) <- databases

--- a/R/api.R
+++ b/R/api.R
@@ -205,7 +205,7 @@ target_run_metadata <- function(runner) {
       })
       names(instances) <- databases
     }
-    instances_supported <- any(viapply(instances, length) > 0)
+    instances_supported <- any(lengths(instances) > 0)
   }
 
   git_supported <- !isTRUE(server_options$master_only) && isTRUE(runner$has_git)

--- a/R/git.R
+++ b/R/git.R
@@ -125,10 +125,10 @@ git_latest_commit <- function(root = NULL) {
   git_run(args, root = root, check = TRUE)$output
 }
 
-
 get_reports <- function(branch, commit, root) {
   if (identical(branch, "master") || is.null(branch)) {
-    ## Get all reports in commit if on master branch
+    ## Get all reports in commit if on master branch and default to latest
+    ## if commit is missing
     if (is.null(commit)) {
       commit <- git_latest_commit(root = root)
     }
@@ -154,6 +154,10 @@ get_reports <- function(branch, commit, root) {
 
 get_report_parameters <- function(report, commit, root) {
   tryCatch({
+    ## Default to latest commit if missing
+    if (is.null(commit)) {
+      commit <- git_latest_commit(root = root)
+    }
     yml <- git_run(
       c("show", paste0(commit, file.path(":src", report, "orderly.yml"))),
       root = root, check = TRUE)

--- a/R/git.R
+++ b/R/git.R
@@ -120,10 +120,18 @@ git_commits <- function(branch, root = NULL) {
   commits
 }
 
+git_latest_commit <- function(root = NULL) {
+  args <- c("log", "--pretty='%h'", "-n", "1")
+  git_run(args, root = root, check = TRUE)$output
+}
+
 
 get_reports <- function(branch, commit, root) {
-  if (branch == "master") {
+  if (identical(branch, "master") || is.null(branch)) {
     ## Get all reports in commit if on master branch
+    if (is.null(commit)) {
+      commit <- git_latest_commit(root = root)
+    }
     reports <- git_run(c("ls-tree", "--name-only", "-d",
                          sprintf("%s:src/", commit)),
                        root = root, check = TRUE)$output

--- a/R/util.R
+++ b/R/util.R
@@ -30,10 +30,6 @@ vcapply <- function(X, FUN, ...) { # nolint
   vapply(X, FUN, character(1), ...)
 }
 
-viapply <- function(X, FUN, ...) { # nolint
-  vapply(X, FUN, integer(1), ...)
-}
-
 protect <- function(fun) {
   fun <- match.fun(fun)
   function() {

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -2,6 +2,7 @@
 
 This API is built on top of [`pkgapi`](https://reside-ic.github.io/pkgapi) (itself influenced by [`hintr`](https://github.com/mrc-ide/hintr) and [montagu api](https://github.com/vimc/montagu-api/blob/master/spec/spec.md)).
 
+
 ## POST /reports/rebuild/
 
 Force orderly to rebuild the index.  This is useful in cases where the index is corrupt (seen in failed restores), or during a schema migration.  It's a relatively harmless operation, though it might get a little slow when the store is large.  Returns nothing.
@@ -148,6 +149,102 @@ Pull from remote git.  This updates the working tree
   " new | 1 +",
   " 1 file changed, 1 insertion(+)",
   " create mode 100644 new"
+]
+```
+
+
+## GET /git/branches/
+
+List git branches whose tips are not reachable from master branch i.e. branches with commits which haven't been merged into master and master branch itself.
+
+## Example
+
+```json
+[
+  {
+    "name":"master",
+    "last_commit":"2021-01-07 12:07:02",
+    "last_commit_age":23
+  },
+  {
+    "name":"other",
+    "last_commit":"2021-01-07 12:07:02",
+    "last_commit_age":23
+  }
+]
+```
+
+
+## GET /git/commits/
+
+List commits hashes, age and time of commit from a branch. If master branch then lists last 25 commits. If any other branch than master it lists unmerged commits up to limit of 25. 
+
+## Example
+
+```json
+[
+  {
+    "id":"b0c9c90",
+    "date_time":"2021-01-07 12:07:02",
+    "age":173
+  }
+]
+
+```
+
+
+## GET /run-metadata/
+
+Get metadata for Orderly Web report runner interface to control UI display
+
+## Example
+
+```json
+{
+  "name": "science",
+  "instances_supported": false,
+  "git_supported": true,
+  "instances": {
+    "source":[]
+  },
+  "changelog_types": [
+    "public"
+  ]
+}
+```
+
+
+## GET /reports/source
+
+List reports which can be run by Orderly Web. 
+
+Reports can be listed
+* With no branch or commit - lists all reports in src dir on latest commit on master branch
+* With a branch other than master & unmerged commit - lists all reports which have changes in them from this commit compared with master branch 
+* With master branch and a commit - lists all reports in src dir on this commit
+
+## Example
+
+```json
+[
+  "global",
+  "minimal"
+]
+```
+
+
+## GET /reports/<report_id>/parameters
+
+List parameters and any default values for a report on a specific commit.
+
+## Example
+
+```json
+[
+  {
+    "name":"nmin",
+    "default":null
+  }
 ]
 ```
 

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -392,6 +392,10 @@ test_that("run-metadata", {
 })
 
 test_that("run-metadata pulls information from runner", {
+
+})
+
+test_that("run-metadata pulls information from runner", {
   path <- orderly::orderly_example("minimal")
   runner <- orderly_runner(path)
 
@@ -574,6 +578,59 @@ test_that("run metadata can get name from config", {
     instances = list(
       source = c(scalar("production"), scalar("staging"))
     ),
+    changelog_types = NULL
+  ))
+})
+
+test_that("run metadata returns git & db instances supported info", {
+  path <- orderly::orderly_example("minimal")
+  yml <- c("database:",
+           "  source:",
+           "    driver: RSQLite::SQLite",
+           "    args:",
+           "      dbname: source.sqlite",
+           "      user: user",
+           "    instances:",
+           "      production:",
+           "        host: production.montagu.dide.ic.ac.uk",
+           "        port: 5432",
+           "        password: pwd",
+           "      staging:",
+           "        host: support.montagu.dide.ic.ac.uk",
+           "        port: 5432",
+           "        password: pwd",
+           "remote:",
+           "  production:",
+           "    driver: RSQLite::SQLite",
+           "    args:",
+           "      dbname: source.sqlite",
+           "      user: user",
+           "      host: production.montagu.dide.ic.ac.uk",
+           "      port: 5432",
+           "      password: pwd",
+           "    slack_url: slack_url",
+           "    teams_url: teams_url",
+           "    primary: TRUE",
+           "    master_only: TRUE",
+           "  staging:",
+           "    driver: RSQLite::SQLite",
+           "    args:",
+           "        host: support.montagu.dide.ic.ac.uk",
+           "        port: 5432",
+           "        password: pwd",
+           "    slack_url: slack_url",
+           "    teams_url: teams_url"
+  )
+  writeLines(yml, file.path(path, "orderly_config.yml"))
+  withr::with_envvar(c("ORDERLY_API_SERVER_IDENTITY" = "production"), {
+    runner <- orderly_runner(path)
+    metadata <- target_run_metadata(runner)
+  })
+  expect_equal(metadata, list(
+    name = scalar("production"),
+    instances_supported = scalar(FALSE),
+    git_supported = scalar(FALSE),
+    instances = NULL,
     changelog_types = NULL
   ))
 })

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -392,10 +392,6 @@ test_that("run-metadata", {
 })
 
 test_that("run-metadata pulls information from runner", {
-
-})
-
-test_that("run-metadata pulls information from runner", {
   path <- orderly::orderly_example("minimal")
   runner <- orderly_runner(path)
 

--- a/tests/testthat/test-git.R
+++ b/tests/testthat/test-git.R
@@ -311,8 +311,10 @@ test_that("can get parameters from a report", {
   expect_equal(params, list(nmin = NULL))
 
   ## get report parameters defaults to latest commit if NULL
-  default_params <- get_report_parameters("global", NULL, path[["origin"]])
-  expect_equal(default_params, NULL)
+  default_params <- get_report_parameters("minimal", NULL, path[["origin"]])
+  expect_equal(default_params, list(a = NULL,
+                                    b = list(default = "test"),
+                                    c = list(default = 2)))
 })
 
 test_that("get_report_parameters handles errors", {

--- a/tests/testthat/test-git.R
+++ b/tests/testthat/test-git.R
@@ -309,6 +309,10 @@ test_that("can get parameters from a report", {
   expect_equal(nrow(other_commits), 1)
   params <- get_report_parameters("other", other_commits$id, path[["local"]])
   expect_equal(params, list(nmin = NULL))
+
+  ## get report parameters defaults to latest commit if NULL
+  default_params <- get_report_parameters("global", NULL, path[["origin"]])
+  expect_equal(params, NULL)
 })
 
 test_that("get_report_parameters handles errors", {

--- a/tests/testthat/test-git.R
+++ b/tests/testthat/test-git.R
@@ -191,6 +191,10 @@ test_that("can get report list from git", {
   expect_equal(nrow(other_commits), 1)
   other_reports <- get_reports("other", other_commits$id, path[["local"]])
   expect_equal(other_reports, "other")
+
+  ## git_commits works with NULL branch and commit
+  default_reports <- get_reports(NULL, NULL, path[["local"]])
+  expect_equal(default_reports, reports)
 })
 
 test_that("report only shows when pushed to remote", {

--- a/tests/testthat/test-git.R
+++ b/tests/testthat/test-git.R
@@ -312,7 +312,7 @@ test_that("can get parameters from a report", {
 
   ## get report parameters defaults to latest commit if NULL
   default_params <- get_report_parameters("global", NULL, path[["origin"]])
-  expect_equal(params, NULL)
+  expect_equal(default_params, NULL)
 })
 
 test_that("get_report_parameters handles errors", {

--- a/tests/testthat/test-runner.R
+++ b/tests/testthat/test-runner.R
@@ -254,11 +254,10 @@ test_that("cleanup", {
 test_that("kill", {
   testthat::skip_on_cran()
   skip_on_windows()
-  skip_on_appveyor()
-  ## TODO: This test is fails to kill the process on travis but adding
-  ## print lines for debugging makes it pass on travis
+  ## TODO: This test is fails to kill the process on CI but adding
+  ## print lines for debugging makes it pass on CI
   ## We should fix this at some point, see VIMC-4066
-  skip_on_travis()
+  skip_on_ci()
   path <- orderly_prepare_orderly_example("interactive", testing = TRUE)
   runner <- orderly_runner(path)
   name <- "interactive"


### PR DESCRIPTION
This PR will
* Return `git_supported` `FALSE` if `master_only` is TRUE for current server
   * Expecting web app will then not show git branch or commit drop downs and send NULL for subsequent report list, report parameter and run report calls
* Return `instances_supported` `FALSE` if `primary` is TRUE for current server
   * Expecting web app will then not show db instances drop down and send NULL for instance in run report call
* If NULL passed to report list or report parameter then default to master branch and most recent commit

Questions
* Should we return a hash of most recent commit in `run-metadata` and then expect that the web app sends this to us in subsequent calls which take it (report list, report parameters, run report)? This will work around cases where 2 users are using app simultaneously, A gets list of parameters for a report, B click button to update git, A tries to run report with out of date parameters
* Is the logic for `git_supported` and `instances_supported` sensible? Maybe both should reflect the same flag `master_only` or `primary`? I see `primary` is used elsewhere to determine which instance should post back to teams/slack, so perhaps isn't super clear how it will be used here.

Tagging you here too @mwoodbri to see the changes