### PR TITLE
VIMC-4573: Add more detail to queue info in status response

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -246,7 +246,9 @@ target_status <- function(runner, key, output = FALSE) {
     status = scalar(res$status),
     version = scalar(res$version),
     output = res$output,
-    queue = lapply(res$queue, scalar)
+    queue = lapply(res$queue, function(item) {
+      lapply(item, scalar)
+    })
   )
 }
 

--- a/inst/schema/Status.schema.json
+++ b/inst/schema/Status.schema.json
@@ -32,8 +32,19 @@
         },
         "queue": {
             "type": "array",
-            "items": { "type": "string" }
-         }
+            "items": {
+                "type": "object",
+                "properties": {
+                    "key": {"type": "string"},
+                    "status": {
+                         "enum": ["queued", "running", "success", "error", "orphan", "interrupted", "redirect", "missing"]
+                    },
+                    "name": {"type": "string"}
+                },
+                "required": ["key", "status", "name"],
+                "additionalProperties": false
+            }
+        }
     },
     "required": ["key", "status", "version", "output", "queue"],
     "additionalProperties": false

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -296,7 +296,16 @@ test_that("status - queued", {
   key <- "key-3"
   status <- list(
     key = key, status = "queued", version = NA_character_,
-    queue = c("key-1", "key-2"))
+    queue = list(
+      list(
+        key = "key-1",
+        status = "running",
+        name = "minimal"
+      ),
+      list(
+        key = "key-2",
+        status = "queued",
+        name = "minimal")))
 
   runner <- mock_runner(key, status)
 
@@ -307,8 +316,16 @@ test_that("status - queued", {
          status = scalar("queued"),
          version = scalar(NA_character_),
          output = NULL,
-         queue = list(scalar("key-1"),
-                       scalar("key-2"))))
+         queue = list(
+           list(
+             key = scalar("key-1"),
+             status = scalar("running"),
+             name = scalar("minimal")
+           ),
+           list(
+             key = scalar("key-2"),
+             status = scalar("queued"),
+             name = scalar("minimal")))))
   expect_equal(mockery::mock_args(runner$status)[[1]], list(key, FALSE))
 
   ## endpoint

--- a/tests/testthat/test-runner.R
+++ b/tests/testthat/test-runner.R
@@ -645,7 +645,7 @@ test_that("runner run passes git args to orderly CLI", {
                        "--id-file", "./runner/id/key.id_file"))
 })
 
-test_that("get_status: lists queued tasks", {
+test_that("status: lists queued tasks", {
   testthat::skip_on_cran()
   skip_on_appveyor()
   skip_on_windows()

--- a/tests/testthat/test-runner.R
+++ b/tests/testthat/test-runner.R
@@ -645,7 +645,7 @@ test_that("runner run passes git args to orderly CLI", {
                        "--id-file", "./runner/id/key.id_file"))
 })
 
-test_that("status: lists queued tasks", {
+test_that("get_status: lists queued tasks", {
   testthat::skip_on_cran()
   skip_on_appveyor()
   skip_on_windows()
@@ -667,9 +667,38 @@ test_that("status: lists queued tasks", {
   expect_equal(runner$status(key1)$status, "running")
   key2_status <- runner$status(key2)
   expect_equal(key2_status$status, "queued")
-  expect_equal(key2_status$queue, list())
+  expect_equal(key2_status$queue, list(
+    list(
+      key = key1,
+      status = "running",
+      name = "interactive"
+    )
+  ))
   key3_status <- runner$status(key3)
   expect_equal(key3_status$status, "queued")
-  expect_equal(key3_status$queue, list(key2))
-  expect_equal(key4_status$queue, list(key2, key3))
+  expect_equal(key3_status$queue, list(
+    list(
+      key = key1,
+      status = "running",
+      name = "interactive"
+    ),
+    list(
+      key = key2,
+      status = "queued",
+      name = "interactive")))
+  expect_equal(key4_status$queue, list(
+    list(
+      key = key1,
+      status = "running",
+      name = "interactive"
+    ),
+    list(
+      key = key2,
+      status = "queued",
+      name = "interactive"
+    ),
+    list(
+      key = key3,
+      status = "queued",
+      name = "interactive")))
 })


### PR DESCRIPTION
This is so that orderlyweb R package can show info about what is currently running (with the name of the report) e.g. https://github.com/vimc/orderlyweb/blob/master/tests/testthat/test-report-run.R#L47