### PR TITLE
VIMC-4550: Add changelog to report run body

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly.server
 Title: Serve Orderly
-Version: 0.3.2
+Version: 0.3.3
 Description: Run orderly reports as a server.
 License: MIT + file LICENSE
 Author: Rich FitzJohn

--- a/R/api.R
+++ b/R/api.R
@@ -253,12 +253,14 @@ endpoint_bundle_import <- function(path, data) {
     returning = returning_json("BundleImport.schema"))
 }
 
-target_run <- function(runner, name, parameters = NULL, ref = NULL,
+target_run <- function(runner, name, body = NULL, ref = NULL,
                        instance = NULL, timeout = 60 * 60 * 3) {
-  if (!is.null(parameters)) {
-    parameters <- jsonlite::fromJSON(parameters)
+  if (!is.null(body)) {
+    body <- jsonlite::fromJSON(body)
   }
-  key <- runner$submit_task_report(name, parameters, ref, instance,
+  changelog <- format_changelog(body$changelog)
+  key <- runner$submit_task_report(name, body$params, ref, instance,
+                                   changelog = changelog,
                                    timeout = timeout)
   list(name = scalar(name),
        key = scalar(key),
@@ -275,7 +277,7 @@ endpoint_run <- function(runner) {
     pkgapi::pkgapi_input_query(ref = "string",
                                instance = "string",
                                timeout = "integer"),
-    pkgapi::pkgapi_input_body_json("parameters", "Parameters.schema",
+    pkgapi::pkgapi_input_body_json("body", "RunRequest.schema",
                                    schema_root()),
     pkgapi::pkgapi_state(runner = runner),
     returning = returning_json("Run.schema"))

--- a/R/util.R
+++ b/R/util.R
@@ -139,3 +139,12 @@ throttle <- function(f, every) {
     }
   }
 }
+
+format_changelog <- function(changelog) {
+  if (is.null(changelog)) {
+    return(changelog)
+  }
+  assert_scalar_character(changelog$type)
+  assert_scalar_character(changelog$message)
+  sprintf("[%s] %s", changelog$type, changelog$message)
+}

--- a/inst/schema/RunRequest.schema.json
+++ b/inst/schema/RunRequest.schema.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "RunRequest",
+    "type": "object",
+    "properties": {
+        "params": { "$ref": "Parameters.schema.json" },
+        "changelog": {
+            "type": "object",
+            "properties": {
+                "message": { "type": "string" },
+                "type": { "type": "string" }
+            },
+            "required": [ "message", "type" ],
+            "additionalProperties": false
+        }
+    },
+    "additionalProperties": false
+}

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -7,7 +7,7 @@ This API is built on top of [`pkgapi`](https://reside-ic.github.io/pkgapi) (itse
 
 Try and run a report `:name`
 
-Accepts as `POST` body json containing parameters and changelog that will be passed through to the report.  This is required when the report requires parameters and is not allowed for reports that do not allow parameters. e.g.
+Accepts as `POST` body json containing `params` and `changelog` that will be passed through to the report.  This is required when the report requires parameters and is not allowed for reports that do not allow parameters. e.g.
 
 ```
 {

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -7,7 +7,19 @@ This API is built on top of [`pkgapi`](https://reside-ic.github.io/pkgapi) (itse
 
 Try and run a report `:name`
 
-Accepts as `POST` body json that will be passed directly through to the report.  This is required when the report requires parameters and is not allowed for reports that do not allow parameters.
+Accepts as `POST` body json containing parameters and changelog that will be passed through to the report.  This is required when the report requires parameters and is not allowed for reports that do not allow parameters. e.g.
+
+```
+{
+  "params": {
+    "nmin": 0.5
+  },
+  "changelog": {
+    "type": "internal",
+    "message": "Added new output plot"
+  }
+}
+```
 
 Accepts the query parameter `ref`, to try running the report against a particular git reference (e.g., a branch or a commit).
 

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -221,7 +221,7 @@ test_that("run", {
          path = scalar(sprintf("/v1/reports/%s/status/", key))))
   expect_equal(
     mockery::mock_args(runner$submit_task_report)[[1]],
-    list("example", NULL, NULL, NULL, timeout = 60 * 60 * 3))
+    list("example", NULL, NULL, NULL, changelog = NULL, timeout = 60 * 60 * 3))
 
   ## endpoint
   endpoint <- endpoint_run(runner)
@@ -243,7 +243,7 @@ test_that("run with parameters", {
   key <- "key-1"
   runner <- mock_runner(key = key)
 
-  res <- target_run(runner, "example", parameters = '{"a": 1}')
+  res <- target_run(runner, "example", body = '{"params": {"a": 1}}')
   expect_equal(
     res,
     list(name = scalar("example"),
@@ -251,7 +251,26 @@ test_that("run with parameters", {
          path = scalar(sprintf("/v1/reports/%s/status/", key))))
   expect_equal(
     mockery::mock_args(runner$submit_task_report)[[1]],
-    list("example", list(a = 1), NULL, NULL, timeout = 60 * 60 * 3))
+    list("example", list(a = 1), NULL, NULL, changelog = NULL,
+         timeout = 60 * 60 * 3))
+})
+
+
+test_that("run with changelog", {
+  key <- "key-1"
+  runner <- mock_runner(key = key)
+
+  res <- target_run(runner, "example",
+                    body = '{"changelog": {"type": "test", "message": "msg"}}')
+  expect_equal(
+    res,
+    list(name = scalar("example"),
+         key = scalar(key),
+         path = scalar(sprintf("/v1/reports/%s/status/", key))))
+  expect_equal(
+    mockery::mock_args(runner$submit_task_report)[[1]],
+    list("example", NULL, NULL, NULL, changelog = "[test] msg",
+         timeout = 60 * 60 * 3))
 })
 
 
@@ -491,7 +510,7 @@ test_that("run can specify instance", {
          path = scalar(sprintf("/v1/reports/%s/status/", key))))
   expect_equal(
     mockery::mock_args(runner$submit_task_report)[[1]],
-    list("example", NULL, NULL, "myinstance", timeout = 100))
+    list("example", NULL, NULL, "myinstance", changelog = NULL, timeout = 100))
 
   ## and via the api
   api <- build_api(runner, "path")
@@ -500,7 +519,7 @@ test_that("run can specify instance", {
                          list(timeout = 100, instance = "myinstance"))
   expect_equal(
     mockery::mock_args(runner$submit_task_report)[[2]],
-    list("example", NULL, NULL, "myinstance", timeout = 100))
+    list("example", NULL, NULL, "myinstance", changelog = NULL, timeout = 100))
 })
 
 test_that("run-metadata", {

--- a/tests/testthat/test-runner.R
+++ b/tests/testthat/test-runner.R
@@ -105,7 +105,8 @@ test_that("runner can run a report", {
   dir_create(dirname(path_id_file(path, "ignore")))
 
   out <- runner_run("key_id", "test_key", path, "minimal", parameters = NULL,
-                    instance = NULL, ref = NULL, has_git = FALSE)
+                    instance = NULL, ref = NULL, has_git = FALSE,
+                    changelog = NULL)
   expect_equal(out$report_name, "minimal")
   expect_match(out$report_id, "^\\d{8}-\\d{6}-\\w{8}")
 
@@ -131,7 +132,7 @@ test_that("runner can run a report with parameters", {
 
   out <- runner_run("key_id", "test_key", path, "other",
                     parameters = list(nmin = 0.5), instance = NULL, ref = NULL,
-                    has_git = FALSE)
+                    has_git = FALSE, changelog = NULL)
   expect_equal(out$report_name, "other")
   expect_match(out$report_id, "^\\d{8}-\\d{6}-\\w{8}")
 
@@ -162,7 +163,7 @@ test_that("runner can return errors", {
 
   err <- expect_error(runner_run("key_report_id", "test_key", path, "example",
                     parameters = NULL, instance = NULL, ref = NULL,
-                    has_git = FALSE))
+                    has_git = FALSE, changelog = NULL))
 
   ## Report ID still can be retrieved
   con <- redux::hiredis()
@@ -620,7 +621,7 @@ test_that("runner run passes git args to orderly CLI", {
     get_exit_status = function() 0L), cycle = TRUE)
   mockery::stub(runner_run, "processx::process$new", mock_processx)
   run <- runner_run("key_report_id", "key", ".", "test", NULL, NULL,
-                    ref = NULL, has_git = TRUE)
+                    ref = NULL, has_git = TRUE, changelog = FALSE)
   mockery::expect_called(mock_processx, 1)
   args <- mockery::mock_args(mock_processx)[[1]][[2]]
   expect_equal(args, c("--root", ".", "run", "test", "--print-log",
@@ -644,6 +645,23 @@ test_that("runner run passes git args to orderly CLI", {
   expect_equal(args, c("--root", ".", "run", "test", "--print-log",
                        "--id-file", "./runner/id/key.id_file"))
 })
+
+
+test_that("runner run passes changelog to orderly CLI", {
+  skip_if_no_redis()
+  mock_processx <- mockery::mock(list(
+    is_alive = function() FALSE,
+    get_exit_status = function() 0L), cycle = TRUE)
+  mockery::stub(runner_run, "processx::process$new", mock_processx)
+  run <- runner_run("key_report_id", "key", ".", "test", NULL, NULL,
+                    ref = NULL, has_git = TRUE, changelog = "[tst] message")
+  mockery::expect_called(mock_processx, 1)
+  args <- mockery::mock_args(mock_processx)[[1]][[2]]
+  expect_equal(args, c("--root", ".", "run", "test", "--print-log",
+                       "--id-file", "./runner/id/key.id_file",
+                       "--pull", "--message", "[tst] message"))
+})
+
 
 test_that("status: lists queued tasks", {
   testthat::skip_on_cran()
@@ -701,4 +719,36 @@ test_that("status: lists queued tasks", {
       key = key3,
       status = "queued",
       name = "interactive")))
+})
+
+test_that("run: changelog", {
+  testthat::skip_on_cran()
+  skip_on_appveyor()
+  skip_on_windows()
+  skip_if_no_redis()
+  path <- orderly_prepare_orderly_example("demo")
+  runner <- orderly_runner(path)
+
+  ## Run a report slow enough to reliably report back a "running" status
+  key <- runner$submit_task_report("minimal", changelog = "[internal] test")
+
+  task_id <- get_task_id_key(runner, key)
+  expect_match(task_id, "^[[:xdigit:]]{32}$")
+  result <- runner$queue$task_wait(task_id)
+  report_id <- result$report_id
+  status <- runner$status(key, output = TRUE)
+  expect_equal(status$key, key)
+  expect_equal(status$status, "success")
+  expect_equal(status$version, report_id)
+
+  ## Report is in archive
+  d <- orderly::orderly_list_archive(path)
+  expect_equal(d$name, "minimal")
+  expect_equal(d$id, report_id)
+
+  d <- readRDS(orderly_path_orderly_run_rds(
+    file.path(path, "archive", "minimal", report_id)))
+  expect_true(!is.null(d$meta$changelog))
+  expect_equal(d$meta$changelog$label, "internal")
+  expect_equal(d$meta$changelog$value, "test")
 })

--- a/tests/testthat/test-runner.R
+++ b/tests/testthat/test-runner.R
@@ -621,7 +621,7 @@ test_that("runner run passes git args to orderly CLI", {
     get_exit_status = function() 0L), cycle = TRUE)
   mockery::stub(runner_run, "processx::process$new", mock_processx)
   run <- runner_run("key_report_id", "key", ".", "test", NULL, NULL,
-                    ref = NULL, has_git = TRUE, changelog = FALSE)
+                    ref = NULL, has_git = TRUE, changelog = NULL)
   mockery::expect_called(mock_processx, 1)
   args <- mockery::mock_args(mock_processx)[[1]][[2]]
   expect_equal(args, c("--root", ".", "run", "test", "--print-log",
@@ -630,7 +630,7 @@ test_that("runner run passes git args to orderly CLI", {
 
   mockery::stub(runner_run, "processx::process$new", mock_processx)
   run <- runner_run("key_report_id", "key", ".", "test", NULL, NULL,
-                    ref = "123", has_git = TRUE)
+                    ref = "123", has_git = TRUE, changelog = NULL)
   mockery::expect_called(mock_processx, 2)
   args <- mockery::mock_args(mock_processx)[[2]][[2]]
   expect_equal(args, c("--root", ".", "run", "test", "--print-log",
@@ -639,7 +639,7 @@ test_that("runner run passes git args to orderly CLI", {
 
   mockery::stub(runner_run, "processx::process$new", mock_processx)
   run <- runner_run("key_report_id", "key", ".", "test", NULL, NULL,
-                    ref = NULL, has_git = FALSE)
+                    ref = NULL, has_git = FALSE, changelog = NULL)
   mockery::expect_called(mock_processx, 3)
   args <- mockery::mock_args(mock_processx)[[3]][[2]]
   expect_equal(args, c("--root", ".", "run", "test", "--print-log",

--- a/tests/testthat/test-runner.R
+++ b/tests/testthat/test-runner.R
@@ -185,7 +185,6 @@ test_that("runner can return errors", {
 
 test_that("run: success", {
   testthat::skip_on_cran()
-  skip_on_appveyor()
   skip_on_windows()
   skip_if_no_redis()
   path <- orderly_prepare_orderly_example("demo")
@@ -230,7 +229,6 @@ test_that("run: success", {
 
 test_that("run: error", {
   testthat::skip_on_cran()
-  skip_on_appveyor()
   skip_on_windows()
   skip_if_no_redis()
 
@@ -278,7 +276,6 @@ test_that("run report with parameters", {
 
 test_that("run in branch (local)", {
   testthat::skip_on_cran()
-  skip_on_appveyor()
   skip_on_windows()
   skip_if_no_redis()
   path <- orderly_unzip_git_demo()
@@ -306,7 +303,6 @@ test_that("prevent ref change", {
 
 test_that("status missing ID", {
   testthat::skip_on_cran()
-  skip_on_appveyor()
   skip_on_windows()
   skip_if_no_redis()
   path <- orderly_prepare_orderly_example("demo")
@@ -323,7 +319,6 @@ test_that("status missing ID", {
 
 test_that("check_timeout kills timed out reports", {
   testthat::skip_on_cran()
-  skip_on_appveyor()
   skip_on_windows()
   skip_if_no_redis()
   path <- orderly_prepare_orderly_example("demo")
@@ -342,7 +337,6 @@ test_that("check_timeout kills timed out reports", {
 
 test_that("check_timeout doesn't kill reports with long timeout", {
   testthat::skip_on_cran()
-  skip_on_appveyor()
   skip_on_windows()
   skip_if_no_redis()
   path <- orderly_prepare_orderly_example("demo")
@@ -357,7 +351,6 @@ test_that("check_timeout doesn't kill reports with long timeout", {
 
 test_that("check_timeout returns NULL if no reports being run", {
   testthat::skip_on_cran()
-  skip_on_appveyor()
   skip_on_windows()
   skip_if_no_redis()
   path <- orderly_prepare_orderly_example("interactive", testing = TRUE)
@@ -369,7 +362,6 @@ test_that("check_timeout returns NULL if no reports being run", {
 
 test_that("check_timeout prints message if fails to kill a report", {
   testthat::skip_on_cran()
-  skip_on_appveyor()
   skip_on_windows()
   skip_if_no_redis()
   path <- orderly_prepare_orderly_example("interactive", testing = TRUE)
@@ -585,7 +577,6 @@ test_that("runner can set instance", {
 
 test_that("status: clears task_timeout from redis", {
   testthat::skip_on_cran()
-  skip_on_appveyor()
   skip_on_windows()
   skip_if_no_redis()
   path <- orderly_prepare_orderly_example("demo")
@@ -665,7 +656,6 @@ test_that("runner run passes changelog to orderly CLI", {
 
 test_that("status: lists queued tasks", {
   testthat::skip_on_cran()
-  skip_on_appveyor()
   skip_on_windows()
   skip_if_no_redis()
   path <- orderly_prepare_orderly_example("interactive", testing = TRUE)
@@ -723,7 +713,6 @@ test_that("status: lists queued tasks", {
 
 test_that("run: changelog", {
   testthat::skip_on_cran()
-  skip_on_appveyor()
   skip_on_windows()
   skip_if_no_redis()
   path <- orderly_prepare_orderly_example("demo")

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -81,4 +81,3 @@ test_that("run server", {
     mockery::mock_args(api$run)[[1]],
     list(host, port))
 })
-

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -81,3 +81,4 @@ test_that("run server", {
     mockery::mock_args(api$run)[[1]],
     list(host, port))
 })
+

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -111,3 +111,11 @@ test_that("throttle does not call functions very often", {
   expect_equal(g(), 2)
   mockery::expect_called(f, 2)
 })
+
+test_that("format_changelog", {
+  expect_equal(format_changelog(list(type = "tst", message = "test")),
+               "[tst] test")
+  expect_error(format_changelog(list(type = "tst")),
+               "'changelog$message' must be a scalar", fixed = TRUE)
+  expect_null(format_changelog(NULL))
+})

--- a/tests/testthat/test-z-integration.R
+++ b/tests/testthat/test-z-integration.R
@@ -416,8 +416,7 @@ test_that("Can pack, run and import a bundle", {
   ans <- orderly::orderly_bundle_run(zip_in, echo = FALSE)
   expect_equal(filename, paste0(ans$id, ".zip"))
 
-  res_up <- httr::POST(
-    "http://localhost:8321/v1/bundle/import",
+  res_up <- httr::POST(server$api_url("/v1/bundle/import"),
     body = httr::upload_file(ans$path, "application/octet-stream"))
   expect_equal(httr::status_code(res), 200L)
   dat <- content(res_up)

--- a/tests/testthat/test-z-integration.R
+++ b/tests/testthat/test-z-integration.R
@@ -232,10 +232,11 @@ test_that("run: pass parameters", {
 })
 
 test_that("run: changelog", {
-  server <- start_test_server()
+  path <- orderly_prepare_orderly_example("demo")
+  server <- start_test_server(path)
   on.exit(server$stop())
 
-  r <- httr::POST(server$api_url("/v1/reports/example/run/"),
+  r <- httr::POST(server$api_url("/v1/reports/minimal/run/"),
                   query = list(timeout = 60),
                   body = list(changelog = list(type = "internal",
                                                message = "test")),
@@ -247,7 +248,7 @@ test_that("run: changelog", {
   expect_is(dat$data, "list")
 
   expect_true(setequal(names(dat$data), c("name", "key", "path")))
-  expect_equal(dat$data$name, "example")
+  expect_equal(dat$data$name, "minimal")
 
   ## Then we ask about status
   wait_for_version(dat$data$key, server)
@@ -258,12 +259,12 @@ test_that("run: changelog", {
   expect_is(st$data, "list")
   version <- st$data$version
 
-  dest <- file.path(server$path, "archive", "example", version)
+  dest <- file.path(server$path, "archive", "minimal", version)
   wait_for_path(dest)
   wait_for_finished(dat$data$key, server)
 
   d <- readRDS(orderly_path_orderly_run_rds(
-    file.path(server$path, "archive", "example", version)))
+    file.path(server$path, "archive", "minimal", version)))
   expect_true(!is.null(d$meta$changelog))
   expect_equal(d$meta$changelog$label, "internal")
   expect_equal(d$meta$changelog$value, "test")

--- a/tests/testthat/test-z-integration.R
+++ b/tests/testthat/test-z-integration.R
@@ -178,14 +178,14 @@ test_that("run report honours timeout", {
 })
 
 
-test_that("pass parameters", {
+test_that("run: pass parameters", {
   path <- orderly_prepare_orderly_example("interactive", testing = TRUE)
   server <- start_test_server(path)
   on.exit(server$stop())
 
   r <- httr::POST(server$api_url("/v1/reports/count_param/run/"),
                   query = list(timeout = 60),
-                  body = list(time = 1, poll = 0.1),
+                  body = list(params = list(time = 1, poll = 0.1)),
                   encode = "json")
 
   expect_equal(httr::status_code(r), 200)
@@ -229,6 +229,44 @@ test_that("pass parameters", {
   ## parameters make it across
   expect_match(st$data$output, "time: 1", fixed = TRUE, all = FALSE)
   expect_match(st$data$output, "poll: 0.1", fixed = TRUE, all = FALSE)
+})
+
+test_that("run: changelog", {
+  server <- start_test_server()
+  on.exit(server$stop())
+
+  r <- httr::POST(server$api_url("/v1/reports/example/run/"),
+                  query = list(timeout = 60),
+                  body = list(changelog = list(type = "internal",
+                                               message = "test")),
+                  encode = "json")
+
+  expect_equal(httr::status_code(r), 200)
+  dat <- content(r)
+  expect_equal(dat$status, "success")
+  expect_is(dat$data, "list")
+
+  expect_true(setequal(names(dat$data), c("name", "key", "path")))
+  expect_equal(dat$data$name, "example")
+
+  ## Then we ask about status
+  wait_for_version(dat$data$key, server)
+  r <- httr::GET(server$api_url(dat$data$path))
+  expect_equal(httr::status_code(r), 200)
+  st <- content(r)
+  expect_equal(st$status, "success")
+  expect_is(st$data, "list")
+  version <- st$data$version
+
+  dest <- file.path(server$path, "archive", "example", version)
+  wait_for_path(dest)
+  wait_for_finished(dat$data$key, server)
+
+  d <- readRDS(orderly_path_orderly_run_rds(
+    file.path(server$path, "archive", "example", version)))
+  expect_true(!is.null(d$meta$changelog))
+  expect_equal(d$meta$changelog$label, "internal")
+  expect_equal(d$meta$changelog$value, "test")
 })
 
 test_that("run-metadata", {


### PR DESCRIPTION
This PR will:
* Add changelog to body of run report and pass through to report runner

Expects changelog to passed in as e.g.
```
{
  "type": "internal",
  "message": "my message"
}
```