### PR TITLE
VIMC-4474: Add missing endpoints to spec and fix errors in spec

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -1,7 +1,7 @@
 build_api <- function(runner, path, backup_period = NULL, rate_limit = 2 * 60) {
   force(runner)
   api <- pkgapi::pkgapi$new()
-  api$handle(endpoint_index())
+  api$handle(endpoint_root())
   api$handle(endpoint_git_status(path))
   api$handle(endpoint_git_fetch(path))
   api$handle(endpoint_git_pull(path))
@@ -74,25 +74,15 @@ returning_json <- function(schema) {
   pkgapi::pkgapi_returning_json(schema, schema_root())
 }
 
-## For compatibility only
-target_index <- function() {
+target_root <- function() {
   list(name = scalar("orderly.server"),
-       version = scalar(as.character(utils::packageVersion("orderly.server"))),
-       endpoints = c(
-         "/",
-         "/v1/reports/:key/kill/",
-         "/v1/reports/:key/status/",
-         "/v1/reports/:name/run/",
-         "/v1/reports/git/fetch/",
-         "/v1/reports/git/pull/",
-         "/v1/reports/git/status/"
-       ))
+       version = scalar(as.character(utils::packageVersion("orderly.server"))))
 }
 
-endpoint_index <- function() {
+endpoint_root <- function() {
   pkgapi::pkgapi_endpoint$new(
-    "GET", "/", target_index,
-    returning = returning_json("Index.schema"))
+    "GET", "/", target_root,
+    returning = returning_json("Root.schema"))
 }
 
 target_git_status <- function(path) {

--- a/inst/schema/Root.schema.json
+++ b/inst/schema/Root.schema.json
@@ -4,12 +4,8 @@
     "type": "object",
     "properties": {
         "name": { "type": "string" },
-        "version": { "type": "string" },
-        "endpoints": {
-            "type": "array",
-            "items": { "type": "string" }
-        }
+        "version": { "type": "string" }
     },
     "additionalProperties": false,
-    "required": [ "name", "version", "endpoints" ]
+    "required": [ "name", "version" ]
 }

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -5,7 +5,7 @@ This API is built on top of [`pkgapi`](https://reside-ic.github.io/pkgapi) (itse
 
 ## GET /
 
-Index of available endpoints, for compatibility only and is not updated.
+Return package name and version
 
 ## POST /reports/:name/run/
 

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -3,6 +3,10 @@
 This API is built on top of [`pkgapi`](https://reside-ic.github.io/pkgapi) (itself influenced by [`hintr`](https://github.com/mrc-ide/hintr) and [montagu api](https://github.com/vimc/montagu-api/blob/master/spec/spec.md)).
 
 
+## GET /
+
+Index of available endpoints, for compatibility only and is not updated.
+
 ## POST /reports/:name/run/
 
 Try and run a report `:name`
@@ -96,7 +100,7 @@ Schema: [`Status.schema.json`](Status.schema.json)
 }
 ```
 
-## DELETE /reports/:name/:version/kill/
+## DELETE /reports/:key/kill/
 
 Kill a running report.  If the report was running then `true` will be returned.  Otherwise an error will be thrown.
 

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -1,12 +1,11 @@
 context("api - endpoints")
 
-test_that("index", {
-  endpoint <- endpoint_index()
+test_that("root", {
+  endpoint <- endpoint_root()
 
   res <- endpoint$target()
   expect_equal(res$name, scalar("orderly.server"))
   expect_equal(res$version, version_info())
-  expect_true("/v1/reports/:key/status/" %in% res$endpoints)
 
   runner <- mock_runner()
   api <- build_api(runner, "path")

--- a/tests/testthat/test-z-integration.R
+++ b/tests/testthat/test-z-integration.R
@@ -8,7 +8,6 @@ test_that("root", {
   dat <- content(r)
   expect_equal(dat$status, "success")
   expect_equal(dat$errors, NULL)
-  expect_is(dat$data$endpoints, "character")
 })
 
 


### PR DESCRIPTION
* Fixes docs on the kill 
* Removes old index from index endpoint and renames this to root

Docs on available_reports and report_parameters added during refactor