### PR TITLE
Add function to return info about queue status

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly.server
 Title: Serve Orderly
-Version: 0.3.7
+Version: 0.3.8
 Description: Run orderly reports as a server.
 License: MIT + file LICENSE
 Author: Rich FitzJohn

--- a/R/api.R
+++ b/R/api.R
@@ -14,6 +14,7 @@ build_api <- function(runner, path, backup_period = NULL, rate_limit = 2 * 60) {
   api$handle(endpoint_report_info(path))
   api$handle(endpoint_run(runner))
   api$handle(endpoint_status(runner))
+  api$handle(endpoint_queue_status(runner))
   api$handle(endpoint_kill(runner))
   api$handle(endpoint_dependencies(path))
   api$handle(endpoint_run_metadata(runner))
@@ -312,6 +313,18 @@ endpoint_status <- function(runner) {
     porcelain::porcelain_input_query(output = "logical"),
     porcelain::porcelain_state(runner = runner),
     returning = returning_json("Status.schema"))
+}
+
+target_queue_status <- function(runner) {
+  res <- runner$queue_status()
+  recursive_scalar(res)
+}
+
+endpoint_queue_status <- function(runner) {
+  porcelain::porcelain_endpoint$new(
+    "GET", "/v1/queue/status/", target_queue_status,
+    porcelain::porcelain_state(runner = runner),
+    returning = returning_json("QueueStatus.schema"))
 }
 
 target_kill <- function(runner, key) {

--- a/R/runner.R
+++ b/R/runner.R
@@ -395,11 +395,17 @@ orderly_runner_ <- R6::R6Class(
 
     get_task_details = function(task_id) {
       key <- self$con$HGET(self$keys$task_id_key, task_id)
+      status <- private$task_status(task_id)
+      report_id <- NULL
+      if (identical(status, "running")) {
+        report_id <- self$con$HGET(self$keys$key_report_id, key)
+      }
       task_data <- self$queue$task_data(task_id)
       list(
         key = key,
-        status = private$task_status(task_id),
-        name = task_data$objects$name
+        status = status,
+        name = task_data$objects$name,
+        version = report_id
       )
     }
   )

--- a/R/runner.R
+++ b/R/runner.R
@@ -290,7 +290,7 @@ orderly_runner_ <- R6::R6Class(
     #'
     #' @return List containing the key, status and report name of any
     #' running tasks and any queued tasks in front of key in the queue.
-    queue_status = function(key) {
+    queue_status = function(key = NULL) {
       running_tasks <- self$queue$worker_task_id()
       if (is.null(key)) {
         queued_tasks <- self$queue$queue_list()

--- a/R/runner.R
+++ b/R/runner.R
@@ -254,7 +254,7 @@ orderly_runner_ <- R6::R6Class(
       }
       out_status <- private$task_status(task_id)
       if (out_status == "queued") {
-        queued <- self$queue_status(key)
+        queued <- self$queue_status(key)$tasks
       } else {
         queued <- list()
       }
@@ -299,7 +299,9 @@ orderly_runner_ <- R6::R6Class(
         queued_tasks <- self$queue$task_preceeding(task_id)
       }
       tasks <- c(running_tasks, queued_tasks)
-      lapply(unname(tasks), private$get_task_details)
+      list(
+        tasks = lapply(unname(tasks), private$get_task_details)
+      )
     },
 
     #' @description

--- a/inst/schema/QueueStatus.schema.json
+++ b/inst/schema/QueueStatus.schema.json
@@ -12,9 +12,12 @@
                     "status": {
                         "enum": ["queued", "running", "success", "error", "orphan", "interrupted", "redirect", "missing"]
                     },
-                    "name": {"type": "string"}
+                    "name": {"type": "string"},
+                    "version": {
+                        "type": [ "string", "null" ]
+                    }
                 },
-                "required": ["key", "status", "name"],
+                "required": ["key", "status", "name", "version"],
                 "additionalProperties": false
             }
         }

--- a/inst/schema/QueueStatus.schema.json
+++ b/inst/schema/QueueStatus.schema.json
@@ -1,19 +1,24 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "QueueStatus",
-    "type": "array",
-    "items": {
-        "type": "object",
-        "properties": {
-            "key": {"type": "string"},
-            "status": {
-                "enum": ["queued", "running", "success", "error", "orphan", "interrupted", "redirect", "missing"]
-            },
-            "name": {"type": "string"}
-        },
-        "required": ["key", "status", "name"],
-        "additionalProperties": false
+    "type": "object",
+    "properties": {
+        "tasks": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "key": {"type": "string"},
+                    "status": {
+                        "enum": ["queued", "running", "success", "error", "orphan", "interrupted", "redirect", "missing"]
+                    },
+                    "name": {"type": "string"}
+                },
+                "required": ["key", "status", "name"],
+                "additionalProperties": false
+            }
+        }
     },
-    "required": ["key", "status", "version", "output", "queue"],
+    "required": [ "tasks" ],
     "additionalProperties": false
 }

--- a/inst/schema/QueueStatus.schema.json
+++ b/inst/schema/QueueStatus.schema.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "QueueStatus",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "key": {"type": "string"},
+            "status": {
+                "enum": ["queued", "running", "success", "error", "orphan", "interrupted", "redirect", "missing"]
+            },
+            "name": {"type": "string"}
+        },
+        "required": ["key", "status", "name"],
+        "additionalProperties": false
+    },
+    "required": ["key", "status", "version", "output", "queue"],
+    "additionalProperties": false
+}

--- a/inst/schema/Status.schema.json
+++ b/inst/schema/Status.schema.json
@@ -30,7 +30,21 @@
                 }
             ]
         },
-        "queue": { "$ref": "QueueStatus.schema.json" }
+        "queue": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "key": {"type": "string"},
+                    "status": {
+                         "enum": ["queued", "running", "success", "error", "orphan", "interrupted", "redirect", "missing"]
+                    },
+                    "name": {"type": "string"}
+                },
+                "required": ["key", "status", "name"],
+                "additionalProperties": false
+            }
+        }
     },
     "required": ["key", "status", "version", "output", "queue"],
     "additionalProperties": false

--- a/inst/schema/Status.schema.json
+++ b/inst/schema/Status.schema.json
@@ -30,21 +30,7 @@
                 }
             ]
         },
-        "queue": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "key": {"type": "string"},
-                    "status": {
-                         "enum": ["queued", "running", "success", "error", "orphan", "interrupted", "redirect", "missing"]
-                    },
-                    "name": {"type": "string"}
-                },
-                "required": ["key", "status", "name"],
-                "additionalProperties": false
-            }
-        }
+        "queue": { "$ref": "QueueStatus.schema.json" }
     },
     "required": ["key", "status", "version", "output", "queue"],
     "additionalProperties": false

--- a/inst/schema/Status.schema.json
+++ b/inst/schema/Status.schema.json
@@ -39,9 +39,12 @@
                     "status": {
                          "enum": ["queued", "running", "success", "error", "orphan", "interrupted", "redirect", "missing"]
                     },
-                    "name": {"type": "string"}
+                    "name": {"type": "string"},
+                    "version": {
+                        "type": [ "string", "null" ]
+                    }
                 },
-                "required": ["key", "status", "name"],
+                "required": ["key", "status", "name", "version"],
                 "additionalProperties": false
             }
         }

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -112,6 +112,31 @@ Schema: [`Status.schema.json`](Status.schema.json)
 }
 ```
 
+## GET /queue/status/
+
+Get the status of the queue.
+
+This returns the key, report name and status of jobs. It includes jobs which are actively running and jobs which are waiting in the queue.
+
+Schema: [`QueueStatus.schema.json`](QueueStatus.schema.json)
+
+### Example queued status
+
+```json
+[
+    {
+        "key": "antiutopian_peregrinefalcon",
+        "status": "running",
+        "name": "minimal"
+    },
+    {
+        "key": "flavoured_bassethound",
+        "status": "queued",
+        "name": "other"
+    }
+]
+```
+
 ## DELETE /reports/:key/kill/
 
 Kill a running report.  If the report was running then `true` will be returned.  Otherwise an error will be thrown.

--- a/man/orderly_runner_.Rd
+++ b/man/orderly_runner_.Rd
@@ -40,7 +40,6 @@ and task_id}
 \item \href{#method-submit}{\code{orderly_runner_$submit()}}
 \item \href{#method-status}{\code{orderly_runner_$status()}}
 \item \href{#method-queue_status}{\code{orderly_runner_$queue_status()}}
-\item \href{#method-get_preceeding_tasks}{\code{orderly_runner_$get_preceeding_tasks()}}
 \item \href{#method-check_timeout}{\code{orderly_runner_$check_timeout()}}
 \item \href{#method-kill}{\code{orderly_runner_$kill()}}
 \item \href{#method-destroy}{\code{orderly_runner_$destroy()}}
@@ -200,29 +199,17 @@ output and the position of the job in the queue.
 \if{html}{\out{<a id="method-queue_status"></a>}}
 \if{latex}{\out{\hypertarget{method-queue_status}{}}}
 \subsection{Method \code{queue_status()}}{
-Get details of jobs in the queue
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{orderly_runner_$queue_status()}\if{html}{\out{</div>}}
-}
+Get the running and queued tasks in front of key in the queue.
 
-\subsection{Returns}{
-List containing the key, status and report name of any
-running tasks and any queued tasks in the queue.
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-get_preceeding_tasks"></a>}}
-\if{latex}{\out{\hypertarget{method-get_preceeding_tasks}{}}}
-\subsection{Method \code{get_preceeding_tasks()}}{
-Get the running and queued tasks in front of key in the queue
+If \code{key} is NULL then includes all queued tasks.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{orderly_runner_$get_preceeding_tasks(key)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{orderly_runner_$queue_status(key = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{key}}{The job key.}
+\item{\code{key}}{The job key, if NULL returns all queued tasks.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/orderly_runner_.Rd
+++ b/man/orderly_runner_.Rd
@@ -39,6 +39,7 @@ and task_id}
 \item \href{#method-submit_task_report}{\code{orderly_runner_$submit_task_report()}}
 \item \href{#method-submit}{\code{orderly_runner_$submit()}}
 \item \href{#method-status}{\code{orderly_runner_$status()}}
+\item \href{#method-queue_status}{\code{orderly_runner_$queue_status()}}
 \item \href{#method-get_preceeding_tasks}{\code{orderly_runner_$get_preceeding_tasks()}}
 \item \href{#method-check_timeout}{\code{orderly_runner_$check_timeout()}}
 \item \href{#method-kill}{\code{orderly_runner_$kill()}}
@@ -120,6 +121,7 @@ Queue a job to run an orderly report.
   parameters = NULL,
   ref = NULL,
   instance = NULL,
+  changelog = NULL,
   poll = 0.1,
   timeout = 60 * 60 * 3
 )}\if{html}{\out{</div>}}
@@ -135,6 +137,8 @@ Queue a job to run an orderly report.
 \item{\code{ref}}{The git sha to run the report.}
 
 \item{\code{instance}}{The db instance for the report to pull data from.}
+
+\item{\code{changelog}}{Description of changes to the report.}
 
 \item{\code{poll}}{How frequently to poll for the report ID being available.}
 
@@ -190,6 +194,20 @@ Get the status of a job
 \subsection{Returns}{
 List containing the key, status, report_id (if available),
 output and the position of the job in the queue.
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-queue_status"></a>}}
+\if{latex}{\out{\hypertarget{method-queue_status}{}}}
+\subsection{Method \code{queue_status()}}{
+Get details of jobs in the queue
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{orderly_runner_$queue_status()}\if{html}{\out{</div>}}
+}
+
+\subsection{Returns}{
+List containing the key, status and report name of any
+running tasks and any queued tasks in the queue.
 }
 }
 \if{html}{\out{<hr>}}

--- a/tests/testthat/helper-orderly.server.R
+++ b/tests/testthat/helper-orderly.server.R
@@ -85,14 +85,16 @@ read_json <- function(path, ...) {
 ## There is going to be some work here to keep these up-to-date:
 mock_runner <- function(key = NULL, status = NULL,
                         config = NULL, root = NULL,
-                        check_timeout = NULL) {
+                        check_timeout = NULL,
+                        queue_status = NULL) {
   list(
     submit_task_report = mockery::mock(key, cycle = TRUE),
     status = mockery::mock(status, cycle = TRUE),
     check_timeout = mockery::mock(check_timeout, cycle = TRUE),
     kill = mockery::mock(TRUE, cycle = TRUE),
     config = config,
-    root = root
+    root = root,
+    queue_status = mockery::mock(queue_status, cycle = TRUE)
   )
 }
 

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -318,12 +318,14 @@ test_that("status - queued", {
       list(
         key = "key-1",
         status = "running",
-        name = "minimal"
+        name = "minimal",
+        version = "20210310-123928-fef89bc7"
       ),
       list(
         key = "key-2",
         status = "queued",
-        name = "minimal")))
+        name = "minimal",
+        version = NULL)))
 
   runner <- mock_runner(key, status)
 
@@ -338,12 +340,14 @@ test_that("status - queued", {
            list(
              key = scalar("key-1"),
              status = scalar("running"),
-             name = scalar("minimal")
+             name = scalar("minimal"),
+             version = scalar("20210310-123928-fef89bc7")
            ),
            list(
              key = scalar("key-2"),
              status = scalar("queued"),
-             name = scalar("minimal")))))
+             name = scalar("minimal"),
+             version = NULL))))
   expect_equal(mockery::mock_args(runner$status)[[1]], list(key, FALSE))
 
   ## endpoint
@@ -443,12 +447,14 @@ test_that("queue status", {
       list(
         key = "key-1",
         status = "running",
-        name = "minimal"
+        name = "minimal",
+        version = "20210310-123928-fef89bc7"
       ),
       list(
         key = "key-2",
         status = "queued",
-        name = "minimal")
+        name = "minimal",
+        version = NULL)
     )
   )
 
@@ -461,12 +467,14 @@ test_that("queue status", {
       list(
         key = scalar("key-1"),
         status = scalar("running"),
-        name = scalar("minimal")
+        name = scalar("minimal"),
+        version = scalar("20210310-123928-fef89bc7")
       ),
       list(
         key = scalar("key-2"),
         status = scalar("queued"),
-        name = scalar("minimal")))))
+        name = scalar("minimal"),
+        version = NULL))))
   mockery::expect_called(runner$queue_status, 1)
 
   ## endpoint

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -439,22 +439,25 @@ test_that("status - completed, with log", {
 
 test_that("queue status", {
   queue_status <- list(
-    list(
-      key = "key-1",
-      status = "running",
-      name = "minimal"
-    ),
-    list(
-      key = "key-2",
-      status = "queued",
-      name = "minimal"))
+    tasks = list(
+      list(
+        key = "key-1",
+        status = "running",
+        name = "minimal"
+      ),
+      list(
+        key = "key-2",
+        status = "queued",
+        name = "minimal")
+    )
+  )
 
   runner <- mock_runner(queue_status = queue_status)
 
   res <- target_queue_status(runner)
   expect_equal(
     res,
-    list(
+    list(tasks = list(
       list(
         key = scalar("key-1"),
         status = scalar("running"),
@@ -463,7 +466,7 @@ test_that("queue status", {
       list(
         key = scalar("key-2"),
         status = scalar("queued"),
-        name = scalar("minimal"))))
+        name = scalar("minimal")))))
   mockery::expect_called(runner$queue_status, 1)
 
   ## endpoint

--- a/tests/testthat/test-runner.R
+++ b/tests/testthat/test-runner.R
@@ -659,14 +659,16 @@ test_that("status: lists queued tasks", {
     expect_equal(key4_status$status, "queued")
   })
   ## Key1 is running, key 2, 3 & 4 are queued
-  expect_equal(runner$status(key1)$status, "running")
+  key1_status <- runner$status(key1)
+  expect_equal(key1_status$status, "running")
   key2_status <- runner$status(key2)
   expect_equal(key2_status$status, "queued")
   expect_equal(key2_status$queue, list(
     list(
       key = key1,
       status = "running",
-      name = "interactive"
+      name = "interactive",
+      version = key1_status$version
     )
   ))
   key3_status <- runner$status(key3)
@@ -675,27 +677,32 @@ test_that("status: lists queued tasks", {
     list(
       key = key1,
       status = "running",
-      name = "interactive"
+      name = "interactive",
+      version = key1_status$version
     ),
     list(
       key = key2,
       status = "queued",
-      name = "interactive")))
+      name = "interactive",
+      version = NULL)))
   expect_equal(key4_status$queue, list(
     list(
       key = key1,
       status = "running",
-      name = "interactive"
+      name = "interactive",
+      version = key1_status$version
     ),
     list(
       key = key2,
       status = "queued",
-      name = "interactive"
+      name = "interactive",
+      version = NULL
     ),
     list(
       key = key3,
       status = "queued",
-      name = "interactive")))
+      name = "interactive",
+      version = NULL)))
 })
 
 test_that("orderly runner won't start if root not under version control", {
@@ -754,21 +761,25 @@ test_that("queue_status", {
   })
 
   ## Key1 is running, key 2, 3 are queued
+  id1 <- runner$status(key1)$version
   queue_status <- runner$queue_status()
   expect_equal(queue_status, list(
     tasks = list(
       list(
         key = key1,
         status = "running",
-        name = "interactive"
+        name = "interactive",
+        version = id1
       ),
       list(
         key = key2,
         status = "queued",
-        name = "interactive"
+        name = "interactive",
+        version = NULL
       ),
       list(
         key = key3,
         status = "queued",
-        name = "interactive"))))
+        name = "interactive",
+        version = NULL))))
 })

--- a/tests/testthat/test-runner.R
+++ b/tests/testthat/test-runner.R
@@ -756,18 +756,19 @@ test_that("queue_status", {
   ## Key1 is running, key 2, 3 are queued
   queue_status <- runner$queue_status()
   expect_equal(queue_status, list(
-    list(
-      key = key1,
-      status = "running",
-      name = "interactive"
-    ),
-    list(
-      key = key2,
-      status = "queued",
-      name = "interactive"
-    ),
-    list(
-      key = key3,
-      status = "queued",
-      name = "interactive")))
+    tasks = list(
+      list(
+        key = key1,
+        status = "running",
+        name = "interactive"
+      ),
+      list(
+        key = key2,
+        status = "queued",
+        name = "interactive"
+      ),
+      list(
+        key = key3,
+        status = "queued",
+        name = "interactive"))))
 })


### PR DESCRIPTION
Requested by Katy, thinking for first cut we can add this function to return info and then render in similar format to what you see when you are waiting on a report after running `orderly_run_remote`