### PR TITLE
mrc-2276: Add workflow missing-dependencies endpoint

### DIFF
--- a/.github/workflows/R-CMD-check-mac.yaml
+++ b/.github/workflows/R-CMD-check-mac.yaml
@@ -58,6 +58,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew install hiredis
+          brew install libgit2
 
       - name: Install dependencies
         run: |

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,4 +35,4 @@ Encoding: UTF-8
 Remotes:
     reside-ic/porcelain,
     ropensci/jsonvalidate,
-    vimc/orderly@mrc-2321
+    vimc/orderly

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Imports:
     heartbeatr,
     ids,
     jsonlite,
-    orderly (>= 1.2.30),
+    orderly (>= 1.2.32),
     porcelain (>= 0.1.0),
     processx,
     redux,
@@ -35,4 +35,4 @@ Encoding: UTF-8
 Remotes:
     reside-ic/porcelain,
     ropensci/jsonvalidate,
-    vimc/orderly
+    vimc/orderly@mrc-2321

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly.server
 Title: Serve Orderly
-Version: 0.3.8
+Version: 0.3.9
 Description: Run orderly reports as a server.
 License: MIT + file LICENSE
 Author: Rich FitzJohn

--- a/R/api.R
+++ b/R/api.R
@@ -416,7 +416,6 @@ target_workflow_validate <- function(path, body) {
   body <- jsonlite::fromJSON(body)
   tasks <- body$tasks
   workflow_validate(path, tasks)
-
 }
 
 endpoint_workflow_validate <- function(path) {

--- a/R/api.R
+++ b/R/api.R
@@ -18,7 +18,7 @@ build_api <- function(runner, path, backup_period = NULL, rate_limit = 2 * 60) {
   api$handle(endpoint_kill(runner))
   api$handle(endpoint_dependencies(path))
   api$handle(endpoint_run_metadata(runner))
-  api$handle(endpoint_workflow_validate(runner))
+  api$handle(endpoint_workflow_validate(path))
   api$setDocs(FALSE)
   backup <- orderly_backup(runner$config, backup_period)
   api$registerHook("preroute", backup$check_backup)

--- a/R/workflows.R
+++ b/R/workflows.R
@@ -10,11 +10,8 @@ workflow_validate <- function(path, tasks) {
 }
 
 get_missing_dependencies <- function(task, path, tasks) {
-  ## Not ideal that we build a graph of all dependencies then throw all
-  ## these away deeper than 1 level, should probably add support for that
-  ## in orderly to avoid unnecessary computation
   graph <- orderly::orderly_graph(task, root = path, direction = "upstream",
-                                  use = "src")
+                                  use = "src", max_depth = 1)
   dependencies <- lapply(graph$root$children, function(vertex) {
     scalar(vertex$name)
   })

--- a/R/workflows.R
+++ b/R/workflows.R
@@ -1,0 +1,4 @@
+workflow_validate <- function(path, tasks) {
+  missing_deps <- lapply(tasks, function(task) "")
+  list(missing_dependencies = setNames(missing_deps, names(tasks)))
+}

--- a/R/workflows.R
+++ b/R/workflows.R
@@ -1,4 +1,4 @@
-workflow_validate <- function(path, tasks) {
+workflow_missing_dependencies <- function(path, tasks) {
   reports <- orderly::orderly_list(root = path)
   missing_deps <- lapply(names(tasks), function(task) {
     if (!(task %in% reports)) {

--- a/R/workflows.R
+++ b/R/workflows.R
@@ -1,4 +1,25 @@
 workflow_validate <- function(path, tasks) {
-  missing_deps <- lapply(tasks, function(task) "")
+  reports <- orderly::orderly_list(root = path)
+  missing_deps <- lapply(names(tasks), function(task) {
+    if (!(task %in% reports)) {
+      stop(sprintf("Task with name '%s' cannot be found.", task))
+    }
+    get_missing_dependencies(task, path, tasks)
+  })
   list(missing_dependencies = setNames(missing_deps, names(tasks)))
+}
+
+get_missing_dependencies <- function(task, path, tasks) {
+  ## Not ideal that we build a graph of all dependencies then throw all
+  ## these away deeper than 1 level, should probably add support for that
+  ## in orderly to avoid unnecessary computation
+  graph <- orderly::orderly_graph(task, root = path, direction = "upstream",
+                                  use = "src")
+  dependencies <- lapply(graph$root$children, function(vertex) {
+    scalar(vertex$name)
+  })
+  ## TODO: consider search query dependencies i.e. latest(parameters:iso3 = iso3)
+  ## these should probably only be considered if their parameter matches between
+  ## dependency and this task
+  deps <- dependencies[!(dependencies %in% names(tasks))]
 }

--- a/R/workflows.R
+++ b/R/workflows.R
@@ -15,9 +15,5 @@ get_missing_dependencies <- function(task, path, tasks) {
   dependencies <- lapply(graph$root$children, function(vertex) {
     scalar(vertex$name)
   })
-  ## TODO: consider search query dependencies i.e.
-  ## latest(parameters:iso3 = iso3)
-  ## these should probably only be considered if their parameter matches between
-  ## dependency and this task
   deps <- dependencies[!(dependencies %in% names(tasks))]
 }

--- a/R/workflows.R
+++ b/R/workflows.R
@@ -18,7 +18,8 @@ get_missing_dependencies <- function(task, path, tasks) {
   dependencies <- lapply(graph$root$children, function(vertex) {
     scalar(vertex$name)
   })
-  ## TODO: consider search query dependencies i.e. latest(parameters:iso3 = iso3)
+  ## TODO: consider search query dependencies i.e.
+  ## latest(parameters:iso3 = iso3)
   ## these should probably only be considered if their parameter matches between
   ## dependency and this task
   deps <- dependencies[!(dependencies %in% names(tasks))]

--- a/inst/schema/WorkflowMissingDependenciesRequest.schema.json
+++ b/inst/schema/WorkflowMissingDependenciesRequest.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "WorkflowValidateRequest",
+    "id": "WorkflowMissingDependenciesRequest",
     "type": "object",
     "properties": {
         "tasks": { "$ref": "WorkflowTasks.schema.json" }

--- a/inst/schema/WorkflowMissingDependenciesResponse.schema.json
+++ b/inst/schema/WorkflowMissingDependenciesResponse.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "WorkflowValidateResponse",
+    "id": "WorkflowMissingDependenciesResponse",
     "type": "object",
     "properties": {
         "missing_dependencies": {

--- a/inst/schema/WorkflowTasks.schema.json
+++ b/inst/schema/WorkflowTasks.schema.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "WorkflowTasks",
+    "definitions": {
+        "task": {
+            "properties": {
+                "ref": { "type": "string" },
+                "instance": { "type": "object" },
+                "params": { "$ref": "Parameters.schema.json" }
+            },
+            "required": [ "ref", "instance" ],
+            "additionalProperties": false
+        }
+    },
+    "type": "object",
+    "patternProperties": {
+        "^.*&": { "$ref": "#/definitions/task" }
+    }
+}

--- a/inst/schema/WorkflowValidateRequest.schema.json
+++ b/inst/schema/WorkflowValidateRequest.schema.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "WorkflowValidateRequest",
+    "type": "object",
+    "properties": {
+        "tasks": { "$ref": "WorkflowTasks.schema.json" }
+    },
+    "required": ["tasks"],
+    "additionalProperties": false
+}

--- a/inst/schema/WorkflowValidateRequest.schema.json
+++ b/inst/schema/WorkflowValidateRequest.schema.json
@@ -6,5 +6,5 @@
         "tasks": { "$ref": "WorkflowTasks.schema.json" }
     },
     "required": ["tasks"],
-    "additionalProperties": false
+    "additionalProperties": true
 }

--- a/inst/schema/WorkflowValidateResponse.schema.json
+++ b/inst/schema/WorkflowValidateResponse.schema.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "WorkflowValidateResponse",
+    "type": "object",
+    "properties": {
+        "missing_dependencies": {
+            "type": "object"
+        }
+    },
+    "required": ["missing_dependencies"],
+    "additionalProperties": false
+}

--- a/tests/testthat/examples/depends/orderly_config.yml
+++ b/tests/testthat/examples/depends/orderly_config.yml
@@ -1,0 +1,5 @@
+database:
+  source:
+    driver: RSQLite::SQLite
+    args:
+      dbname: source.sqlite

--- a/tests/testthat/examples/depends/src/depend/orderly.yml
+++ b/tests/testthat/examples/depends/src/depend/orderly.yml
@@ -1,0 +1,14 @@
+data: ~
+depends:
+  example:
+    id: latest
+    use:
+      previous.rds: data.rds
+script: script.R
+artefacts:
+  - staticgraph:
+      description: a plot
+      filenames: mygraph.png
+  - data:
+      description: some data
+      filenames: output.rds

--- a/tests/testthat/examples/depends/src/depend/script.R
+++ b/tests/testthat/examples/depends/src/depend/script.R
@@ -1,0 +1,7 @@
+dat <- readRDS("previous.rds")
+png("mygraph.png")
+par(mar = c(15, 4, .5, .5))
+barplot(setNames(dat$number, dat$name), las = 2)
+dev.off()
+
+saveRDS(orderly::orderly_run_info(), "output.rds")

--- a/tests/testthat/examples/depends/src/depend2/orderly.yml
+++ b/tests/testthat/examples/depends/src/depend2/orderly.yml
@@ -1,0 +1,18 @@
+data: ~
+depends:
+  - example:
+      id: latest
+      use:
+        previous1.rds: data.rds
+  - example:
+      id: latest
+      use:
+        previous2.rds: data.rds
+script: script.R
+artefacts:
+  - data:
+      description: results
+      filenames: results.rds
+  - data:
+      description: some data
+      filenames: output.rds

--- a/tests/testthat/examples/depends/src/depend2/script.R
+++ b/tests/testthat/examples/depends/src/depend2/script.R
@@ -1,0 +1,5 @@
+dat1 <- readRDS("previous1.rds")
+dat2 <- readRDS("previous2.rds")
+
+saveRDS(list(dat1, dat2), "results.rds")
+saveRDS(orderly::orderly_run_info(), "output.rds")

--- a/tests/testthat/examples/depends/src/depend3/orderly.yml
+++ b/tests/testthat/examples/depends/src/depend3/orderly.yml
@@ -1,0 +1,18 @@
+data: ~
+depends:
+  - depend2:
+      id: latest
+      use:
+        previous1.rds: results.rds
+  - depend2:
+      id: latest
+      use:
+        previous2.rds: output.rds
+script: script.R
+artefacts:
+  - data:
+      description: results
+      filenames: results.rds
+  - data:
+      description: some data
+      filenames: output.rds

--- a/tests/testthat/examples/depends/src/depend3/script.R
+++ b/tests/testthat/examples/depends/src/depend3/script.R
@@ -1,0 +1,5 @@
+dat1 <- readRDS("previous1.rds")
+dat2 <- readRDS("previous2.rds")
+
+saveRDS(list(dat1, dat2), "results.rds")
+saveRDS(orderly::orderly_run_info(), "output.rds")

--- a/tests/testthat/examples/depends/src/depend4/orderly.yml
+++ b/tests/testthat/examples/depends/src/depend4/orderly.yml
@@ -1,0 +1,18 @@
+data: ~
+depends:
+  - example:
+      id: latest
+      use:
+        previous1.rds: data.rds
+  - depend2:
+      id: latest
+      use:
+        previous2.rds: results.rds
+script: script.R
+artefacts:
+  - data:
+      description: results
+      filenames: results.rds
+  - data:
+      description: some data
+      filenames: output.rds

--- a/tests/testthat/examples/depends/src/depend4/script.R
+++ b/tests/testthat/examples/depends/src/depend4/script.R
@@ -1,0 +1,5 @@
+dat1 <- readRDS("previous1.rds")
+dat2 <- readRDS("previous2.rds")
+
+saveRDS(list(dat1, dat2), "results.rds")
+saveRDS(orderly::orderly_run_info(), "output.rds")

--- a/tests/testthat/examples/depends/src/example/orderly.yml
+++ b/tests/testthat/examples/depends/src/example/orderly.yml
@@ -1,0 +1,8 @@
+data:
+  dat:
+    query: SELECT name, number FROM thing
+script: script.R
+artefacts:
+  data:
+    description: some data
+    filenames: data.rds

--- a/tests/testthat/examples/depends/src/example/script.R
+++ b/tests/testthat/examples/depends/src/example/script.R
@@ -1,0 +1,2 @@
+dat$number <- dat$number + rnorm(nrow(dat))
+saveRDS(dat, "data.rds")

--- a/tests/testthat/examples/interactive/src/depend/orderly.yml
+++ b/tests/testthat/examples/interactive/src/depend/orderly.yml
@@ -1,0 +1,14 @@
+data: ~
+depends:
+  example:
+    id: latest
+    use:
+      previous.rds: data.rds
+script: script.R
+artefacts:
+  - staticgraph:
+      description: a plot
+      filenames: mygraph.png
+  - data:
+      description: some data
+      filenames: output.rds

--- a/tests/testthat/examples/interactive/src/depend/script.R
+++ b/tests/testthat/examples/interactive/src/depend/script.R
@@ -1,0 +1,7 @@
+dat <- readRDS("previous.rds")
+png("mygraph.png")
+par(mar = c(15, 4, .5, .5))
+barplot(setNames(dat$number, dat$name), las = 2)
+dev.off()
+
+saveRDS(orderly::orderly_run_info(), "output.rds")

--- a/tests/testthat/test-api-workflows.R
+++ b/tests/testthat/test-api-workflows.R
@@ -1,3 +1,5 @@
+context("api-workflows")
+
 test_that("workflow can be validated", {
   t <- tempfile()
   writeLines(jsonlite::toJSON(list(

--- a/tests/testthat/test-api-workflows.R
+++ b/tests/testthat/test-api-workflows.R
@@ -1,0 +1,52 @@
+test_that("workflow can be validated", {
+  t <- tempfile()
+  writeLines(jsonlite::toJSON(list(
+    tasks = list(
+      preprocess = list(
+        ref = scalar("123"),
+        instance = list(
+          source = scalar("production")
+        ),
+        params = list(
+          nmin = scalar(0.5),
+          nmax = scalar(2)
+        )
+      ),
+      process = list(
+        ref = scalar("ba123"),
+        instance = list(
+          source = scalar("production")
+        )
+      ),
+      postprocess = list(
+        ref = scalar("2134"),
+        instance = list(
+          source = scalar("production")
+        )
+      )
+    )
+  )), t)
+
+  res <- target_workflow_validate("path", t)
+  expect_equal(res,
+               list(missing_dependencies = list(
+                 preprocess = "",
+                 process = "",
+                 postprocess = ""
+               )))
+
+  ## endpoint
+  endpoint <- endpoint_workflow_validate("path")
+  res_endpoint <- endpoint$run(t)
+  expect_equal(res_endpoint$status_code, 200)
+  expect_equal(res_endpoint$data, res)
+
+  ## api
+  runner <- mock_runner()
+  api <- build_api(runner, "path")
+  res_api <- api$request("POST", "/v1/workflow/validate/",
+                         body = readLines(t))
+  expect_equal(res_api$status, 200L)
+  expect_equal(res_api$headers[["Content-Type"]], "application/json")
+  expect_equal(res_api$body, as.character(res_endpoint$body))
+})

--- a/tests/testthat/test-api-workflows.R
+++ b/tests/testthat/test-api-workflows.R
@@ -30,37 +30,40 @@ test_that("workflow can be validated", {
     )
   )), t)
 
-  validate_output <- list(
+  output <- list(
     missing_dependencies = list(
       preprocess = "",
       process = "",
       postprocess = ""
     )
   )
-  mock_validate <- mockery::mock(validate_output, cycle = TRUE)
-  with_mock("orderly.server:::workflow_validate" = mock_validate, {
-    res <- target_workflow_validate(path, t)
+  mock_missing_dependencies <- mockery::mock(output, cycle = TRUE)
+  with_mock("orderly.server:::workflow_missing_dependencies" =
+              mock_missing_dependencies, {
+    res <- target_workflow_missing_dependencies(path, t)
   })
-  mockery::expect_called(mock_validate, 1)
-  expect_equal(res, validate_output)
+  mockery::expect_called(mock_missing_dependencies, 1)
+  expect_equal(res, output)
 
   ## endpoint
-  with_mock("orderly.server:::workflow_validate" = mock_validate, {
-    endpoint <- endpoint_workflow_validate(path)
+  with_mock("orderly.server:::workflow_missing_dependencies" =
+              mock_missing_dependencies, {
+    endpoint <- endpoint_workflow_missing_dependencies(path)
     res_endpoint <- endpoint$run(t)
   })
   expect_equal(res_endpoint$status_code, 200)
   expect_equal(res_endpoint$data, res)
-  mockery::expect_called(mock_validate, 2)
+  mockery::expect_called(mock_missing_dependencies, 2)
 
   ## api
-  with_mock("orderly.server:::workflow_validate" = mock_validate, {
+  with_mock("orderly.server:::workflow_missing_dependencies" =
+              mock_missing_dependencies, {
     api <- build_api(mock_runner(), path)
-    res_api <- api$request("POST", "/v1/workflow/validate/",
+    res_api <- api$request("POST", "/v1/workflow/missing-dependencies/",
                            body = readLines(t))
   })
   expect_equal(res_api$status, 200L)
   expect_equal(res_api$headers[["Content-Type"]], "application/json")
   expect_equal(res_api$body, as.character(res_endpoint$body))
-  mockery::expect_called(mock_validate, 3)
+  mockery::expect_called(mock_missing_dependencies, 3)
 })

--- a/tests/testthat/test-api-workflows.R
+++ b/tests/testthat/test-api-workflows.R
@@ -1,6 +1,7 @@
 context("api-workflows")
 
 test_that("workflow can be validated", {
+  path <- orderly_prepare_orderly_example("minimal")
   t <- tempfile()
   writeLines(jsonlite::toJSON(list(
     tasks = list(
@@ -29,26 +30,37 @@ test_that("workflow can be validated", {
     )
   )), t)
 
-  res <- target_workflow_validate("path", t)
-  expect_equal(res,
-               list(missing_dependencies = list(
-                 preprocess = "",
-                 process = "",
-                 postprocess = ""
-               )))
+  validate_output <- list(
+    missing_dependencies = list(
+      preprocess = "",
+      process = "",
+      postprocess = ""
+    )
+  )
+  mock_validate <- mockery::mock(validate_output, cycle = TRUE)
+  with_mock("orderly.server:::workflow_validate" = mock_validate, {
+    res <- target_workflow_validate(path, t)
+  })
+  mockery::expect_called(mock_validate, 1)
+  expect_equal(res, validate_output)
 
   ## endpoint
-  endpoint <- endpoint_workflow_validate("path")
-  res_endpoint <- endpoint$run(t)
+  with_mock("orderly.server:::workflow_validate" = mock_validate, {
+    endpoint <- endpoint_workflow_validate(path)
+    res_endpoint <- endpoint$run(t)
+  })
   expect_equal(res_endpoint$status_code, 200)
   expect_equal(res_endpoint$data, res)
+  mockery::expect_called(mock_validate, 2)
 
   ## api
-  runner <- mock_runner()
-  api <- build_api(runner, "path")
-  res_api <- api$request("POST", "/v1/workflow/validate/",
-                         body = readLines(t))
+  with_mock("orderly.server:::workflow_validate" = mock_validate, {
+    api <- build_api(mock_runner(), path)
+    res_api <- api$request("POST", "/v1/workflow/validate/",
+                           body = readLines(t))
+  })
   expect_equal(res_api$status, 200L)
   expect_equal(res_api$headers[["Content-Type"]], "application/json")
   expect_equal(res_api$body, as.character(res_endpoint$body))
+  mockery::expect_called(mock_validate, 3)
 })

--- a/tests/testthat/test-runner.R
+++ b/tests/testthat/test-runner.R
@@ -657,6 +657,8 @@ test_that("status: lists queued tasks", {
     key4_status <- runner$status(key4)
     expect_equal(key4_status$key, key4)
     expect_equal(key4_status$status, "queued")
+    key1_status <- runner$status(key1)
+    expect_true(!is.null(key1_status$version))
   })
   ## Key1 is running, key 2, 3 & 4 are queued
   key1_status <- runner$status(key1)

--- a/tests/testthat/test-workflows.R
+++ b/tests/testthat/test-workflows.R
@@ -1,25 +1,25 @@
 context("workflows")
 
 
-test_that("workflow validate erros if report not found", {
+test_that("workflow missing dependencies errors if report not found", {
   path <- orderly_prepare_orderly_example("minimal")
   tasks <- list(
     missing_task = list(
       ref = "123"
     )
   )
-  expect_error(workflow_validate(path, tasks),
+  expect_error(workflow_missing_dependencies(path, tasks),
                "Task with name 'missing_task' cannot be found.")
 })
 
-test_that("workflow can be validated", {
+test_that("can get missing dependencies of a workflow", {
   path <- orderly_prepare_orderly_example("demo")
   tasks <- list(
     other = list(
       ref = "123"
     )
   )
-  expect_equal(workflow_validate(path, tasks),
+  expect_equal(workflow_missing_dependencies(path, tasks),
                list(missing_dependencies = list(
                  other = list()
                )))
@@ -29,7 +29,7 @@ test_that("workflow can be validated", {
       ref = "123"
     )
   )
-  expect_equal(workflow_validate(path, tasks),
+  expect_equal(workflow_missing_dependencies(path, tasks),
                list(missing_dependencies = list(
                  use_dependency = list(scalar("other"))
                )))
@@ -42,27 +42,27 @@ test_that("workflow can be validated", {
       ref = "abc"
     )
   )
-  expect_equal(workflow_validate(path, tasks),
+  expect_equal(workflow_missing_dependencies(path, tasks),
                list(missing_dependencies = list(
                  use_dependency = list(),
                  other = list()
                )))
 })
 
-test_that("workflow validate only looks at depth 1 dependencies", {
+test_that("workflow missing dependencies only looks at depth 1 dependencies", {
   path <- orderly_prepare_orderly_example("demo")
   tasks <- list(
     use_dependency_2 = list(
       ref = "123"
     )
   )
-  expect_equal(workflow_validate(path, tasks),
+  expect_equal(workflow_missing_dependencies(path, tasks),
                list(missing_dependencies = list(
                  use_dependency_2 = list(scalar("use_dependency"))
                )))
 })
 
-test_that("workflow validate can handle multiple dependencies", {
+test_that("workflow missing dependencies can handle multiple dependencies", {
   path <- orderly_prepare_orderly_example("depends", testing = TRUE)
 
   tasks <- list(
@@ -70,7 +70,7 @@ test_that("workflow validate can handle multiple dependencies", {
       ref = "123"
     )
   )
-  expect_equal(workflow_validate(path, tasks),
+  expect_equal(workflow_missing_dependencies(path, tasks),
                list(missing_dependencies = list(
                  depend4 = list(scalar("example"), scalar("depend2")))
                ))
@@ -83,7 +83,7 @@ test_that("workflow validate can handle multiple dependencies", {
       ref = "123"
     )
   )
-  expect_equal(workflow_validate(path, tasks),
+  expect_equal(workflow_missing_dependencies(path, tasks),
                list(missing_dependencies = list(
                  depend4 = list(scalar("example")),
                  depend2 =  list(scalar("example")))
@@ -95,7 +95,7 @@ test_that("workflow validate can handle multiple dependencies", {
       ref = "123"
     )
   )
-  expect_equal(workflow_validate(path, tasks),
+  expect_equal(workflow_missing_dependencies(path, tasks),
                list(missing_dependencies = list(
                  depend2 = list(scalar("example"))
                )))

--- a/tests/testthat/test-workflows.R
+++ b/tests/testthat/test-workflows.R
@@ -61,3 +61,42 @@ test_that("workflow validate only looks at depth 1 dependencies", {
                  use_dependency_2 = list(scalar("use_dependency"))
                )))
 })
+
+test_that("workflow validate can handle multiple dependencies", {
+  path <- orderly_prepare_orderly_example("depends", testing = TRUE)
+
+  tasks <- list(
+    depend4 = list(
+      ref = "123"
+    )
+  )
+  expect_equal(workflow_validate(path, tasks),
+               list(missing_dependencies = list(
+                 depend4 = list(scalar("example"), scalar("depend2")))
+               ))
+
+  tasks <- list(
+    depend4 = list(
+      ref = "123"
+    ),
+    depend2 = list(
+      ref = "123"
+    )
+  )
+  expect_equal(workflow_validate(path, tasks),
+               list(missing_dependencies = list(
+                 depend4 = list(scalar("example")),
+                 depend2 =  list(scalar("example")))
+               ))
+
+
+  tasks <- list(
+    depend2 = list(
+      ref = "123"
+    )
+  )
+  expect_equal(workflow_validate(path, tasks),
+               list(missing_dependencies = list(
+                 depend2 = list(scalar("example"))
+               )))
+})

--- a/tests/testthat/test-workflows.R
+++ b/tests/testthat/test-workflows.R
@@ -1,0 +1,63 @@
+context("workflows")
+
+
+test_that("workflow validate erros if report not found", {
+  path <- orderly_prepare_orderly_example("minimal")
+  tasks <- list(
+    missing_task = list(
+      ref = "123"
+    )
+  )
+  expect_error(workflow_validate(path, tasks),
+               "Task with name 'missing_task' cannot be found.")
+})
+
+test_that("workflow can be validated", {
+  path <- orderly_prepare_orderly_example("demo")
+  tasks <- list(
+    other = list(
+      ref = "123"
+    )
+  )
+  expect_equal(workflow_validate(path, tasks),
+               list(missing_dependencies = list(
+                 other = list()
+               )))
+
+  tasks <- list(
+    use_dependency = list(
+      ref = "123"
+    )
+  )
+  expect_equal(workflow_validate(path, tasks),
+               list(missing_dependencies = list(
+                 use_dependency = list(scalar("other"))
+               )))
+
+  tasks <- list(
+    use_dependency = list(
+      ref = "123"
+    ),
+    other = list(
+      ref = "abc"
+    )
+  )
+  expect_equal(workflow_validate(path, tasks),
+               list(missing_dependencies = list(
+                 use_dependency = list(),
+                 other = list()
+               )))
+})
+
+test_that("workflow validate only looks at depth 1 dependencies", {
+  path <- orderly_prepare_orderly_example("demo")
+  tasks <- list(
+    use_dependency_2 = list(
+      ref = "123"
+    )
+  )
+  expect_equal(workflow_validate(path, tasks),
+               list(missing_dependencies = list(
+                 use_dependency_2 = list(scalar("use_dependency"))
+               )))
+})

--- a/tests/testthat/test-z-integration.R
+++ b/tests/testthat/test-z-integration.R
@@ -513,7 +513,6 @@ test_that("can validate workflow", {
   server <- start_test_server()
   on.exit(server$stop())
 
-  ## Run a report first to retrieve info for
   r <- httr::POST(server$api_url("/v1/workflow/validate/"),
                   body = list(tasks = list(
                     depend = list(

--- a/tests/testthat/test-z-integration.R
+++ b/tests/testthat/test-z-integration.R
@@ -509,11 +509,11 @@ test_that("can get report info", {
   expect_equal(info$data$params$poll, 0.1)
 })
 
-test_that("can validate workflow", {
+test_that("can get missing dependencies of a workflow", {
   server <- start_test_server()
   on.exit(server$stop())
 
-  r <- httr::POST(server$api_url("/v1/workflow/validate/"),
+  r <- httr::POST(server$api_url("/v1/workflow/missing-dependencies/"),
                   body = list(tasks = list(
                     depend = list(
                       ref = "123",

--- a/tests/testthat/test-z-integration.R
+++ b/tests/testthat/test-z-integration.R
@@ -508,3 +508,27 @@ test_that("can get report info", {
   expect_equal(info$data$params$time, 1)
   expect_equal(info$data$params$poll, 0.1)
 })
+
+test_that("can validate workflow", {
+  server <- start_test_server()
+  on.exit(server$stop())
+
+  ## Run a report first to retrieve info for
+  r <- httr::POST(server$api_url("/v1/workflow/validate/"),
+                  body = list(tasks = list(
+                    depend = list(
+                      ref = "123",
+                      instance = list(source = "production")
+                    )
+                  )),
+                  encode = "json")
+
+  expect_equal(httr::status_code(r), 200)
+  dat <- content(r)
+  expect_equal(dat$status, "success")
+  expect_equal(dat$data, list(
+    missing_dependencies = list(
+      depend = "example"
+    )
+  ))
+})


### PR DESCRIPTION
This PR will:
* Add endpoint to get missing dependencies of a workflow

This is just considering a report as a `dependency` if it is linked with `id: latest` or search term dependencies `id: latest(parameter:nmin == nmin)`. 

There is a bit of an awkward edge case with search terms,
if we have
```
steps:
  - preprocess:
      params:
        nmin: 5
  - process:
      params:
        nmin: 7
  - postprocess:
```
and `process` has `orderly.yml` containing
```
parameters:
  nmin: ~
depends:
  preprocess:
    id: latest(parameter:nmin == nmin)
```

Then should this flag `preprocess` as a missing dependency of `process` because the values of the params are different? I think probably so right? Cautious not to make this validation too clever though, just presenting the information might be easier


Note I am expecting the run workflow to have the same input json (probably with a couple of extra fields but the `tasks` as they are here)
