### PR TITLE
Use new porcelain logging

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -4,3 +4,5 @@ ignored:
   # https://github.com/hadolint/hadolint/wiki/DL3008
   # I can't imagine ever wanting this
   - DL3008
+  # Consecutive run commands, we do want that between system deps and packages
+  - DL3059

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly.server
 Title: Serve Orderly
-Version: 0.3.15
+Version: 0.3.16
 Description: Run orderly reports as a server.
 License: MIT + file LICENSE
 Author: Rich FitzJohn
@@ -12,8 +12,9 @@ Imports:
     docopt (>= 0.7.1),
     ids,
     jsonlite,
+    lgr,
     orderly (>= 1.3.7),
-    porcelain (>= 0.1.0),
+    porcelain (>= 0.1.4),
     processx,
     redux,
     rrq (>= 0.5.0),

--- a/R/logging.R
+++ b/R/logging.R
@@ -1,0 +1,12 @@
+make_logger <- function(log_level, path = NULL) {
+  logger <- lgr::get_logger("orderly.server", reset = TRUE)
+  logger$set_propagate(FALSE)
+  logger$set_threshold(log_level)
+  if (is.null(path)) {
+    appender <- lgr::AppenderConsole$new(layout = lgr::LayoutJson$new())
+  } else {
+    appender <- lgr::AppenderJson$new(path)
+  }
+  logger$add_appender(appender, name = "json")
+  logger
+}

--- a/R/server.R
+++ b/R/server.R
@@ -29,18 +29,24 @@
 ##' @param backup_period How frequently should backup be run, if NULL backup
 ##' is skipped
 ##'
+##' @param log_level The "lgr" log level to use
+##'
 ##' @export
 server <- function(path, port, host = "0.0.0.0", allow_ref = TRUE,
                    go_signal = NULL, queue_id = NULL, workers = 1,
-                   backup_period = 600, timeout_rate_limit = 2 * 60) {
+                   backup_period = 600, timeout_rate_limit = 2 * 60,
+                   log_level = "info") {
   message("Starting orderly server on port ", port)
   message("Orderly root: ", path)
 
   wait_for_go_signal(path, go_signal)
   runner <- orderly_runner(path, allow_ref, queue_id = queue_id,
                            workers = workers)
-  api <- build_api(runner, runner$root, backup_period,
-                   rate_limit = timeout_rate_limit)
+  logger <- make_logger(log_level)
+  api <- build_api(runner, runner$root,
+                   backup_period = backup_period,
+                   rate_limit = timeout_rate_limit,
+                   logger = logger)
   api$run(host, port)
 
   message("Server exiting")

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get update || apt-get update && apt-get install -y \
   libv8-dev \
   openssh-client
 
+COPY docker/bin /usr/local/bin/
+
 RUN install2.r --error \
         --repos https://cloud.r-project.org \
         --repos https://vimc.github.io/drat \
@@ -18,14 +20,12 @@ RUN install2.r --error \
         remotes \
         webutils
 
-COPY docker/bin /usr/local/bin/
+COPY . /src
 
 RUN install_remote \
-  mrc-ide/rrq \
-  ropensci/jsonvalidate
-
-COPY . /src
-RUN R CMD INSTALL /src
+        mrc-ide/rrq \
+        ropensci/jsonvalidate \
+        && R CMD INSTALL /src
 
 EXPOSE 8321
 ENV ORDERLY_SERVER_QUEUE_ID=orderly.server

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,6 +12,7 @@ RUN install2.r --error \
         --repos https://vimc.github.io/drat \
         callr \
         jsonlite \
+        lgr \
         porcelain \
         processx \
         remotes \
@@ -22,8 +23,6 @@ COPY docker/bin /usr/local/bin/
 RUN install_remote \
   mrc-ide/rrq \
   ropensci/jsonvalidate
-
-RUN Rscript -e 'remotes::install_github("reside-ic/porcelain@22eef9b")'
 
 COPY . /src
 RUN R CMD INSTALL /src

--- a/man/orderly_runner_.Rd
+++ b/man/orderly_runner_.Rd
@@ -18,6 +18,12 @@ Object for managing running jobs on the redis queue
 
 \item{\code{allow_ref}}{Allow git to change branch/ref for run}
 
+\item{\code{alternative_root}}{A copy of Orderly root in some tempdir.
+This is a copy we can safely switch the git ref on for e.g.
+finding report dependencies on a particular branch. This avoids
+changing the checked out branch on the main root, potentially
+causing issues for anything else which relies on global state}
+
 \item{\code{con}}{Redis connection}
 
 \item{\code{cleanup_on_exit}}{If TRUE workers are killed on exit}
@@ -36,10 +42,12 @@ and task_id}
 \itemize{
 \item \href{#method-new}{\code{orderly_runner_$new()}}
 \item \href{#method-start_workers}{\code{orderly_runner_$start_workers()}}
+\item \href{#method-assert_ref_switching_allowed}{\code{orderly_runner_$assert_ref_switching_allowed()}}
 \item \href{#method-submit_task_report}{\code{orderly_runner_$submit_task_report()}}
-\item \href{#method-submit_workflow}{\code{orderly_runner_$submit_workflow()}}
 \item \href{#method-submit}{\code{orderly_runner_$submit()}}
+\item \href{#method-submit_workflow}{\code{orderly_runner_$submit_workflow()}}
 \item \href{#method-status}{\code{orderly_runner_$status()}}
+\item \href{#method-workflow_status}{\code{orderly_runner_$workflow_status()}}
 \item \href{#method-queue_status}{\code{orderly_runner_$queue_status()}}
 \item \href{#method-check_timeout}{\code{orderly_runner_$check_timeout()}}
 \item \href{#method-kill}{\code{orderly_runner_$kill()}}
@@ -111,6 +119,28 @@ TRUE, called for side effects.
 }
 }
 \if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-assert_ref_switching_allowed"></a>}}
+\if{latex}{\out{\hypertarget{method-assert_ref_switching_allowed}{}}}
+\subsection{Method \code{assert_ref_switching_allowed()}}{
+Check if ref switching is allowed in this runner. Errors if
+ref is non NULL and ref switching disallowed, otherwise
+does nothing.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{orderly_runner_$assert_ref_switching_allowed(ref)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{ref}}{Input ref to check}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+TRUE, called for side effects.
+}
+}
+\if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-submit_task_report"></a>}}
 \if{latex}{\out{\hypertarget{method-submit_task_report}{}}}
 \subsection{Method \code{submit_task_report()}}{
@@ -123,7 +153,8 @@ Queue a job to run an orderly report.
   instance = NULL,
   changelog = NULL,
   poll = 0.1,
-  timeout = 60 * 60 * 3
+  timeout = 60 * 60 * 3,
+  depends_on = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -143,12 +174,36 @@ Queue a job to run an orderly report.
 \item{\code{poll}}{How frequently to poll for the report ID being available.}
 
 \item{\code{timeout}}{Timeout for the report run default 3 hours.}
+
+\item{\code{depends_on}}{Keys of any tasks which this report depends on}
 }
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
 The key for the job, note this is not the task id. The task id
 can be retrieved from redis using the key.
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-submit"></a>}}
+\if{latex}{\out{\hypertarget{method-submit}{}}}
+\subsection{Method \code{submit()}}{
+Submit an arbitrary job on the queue
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{orderly_runner_$submit(expr, depends_on = NULL)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{depends_on}}{Task ids for any dependencies of this job.}
+
+\item{\code{job}}{A quoted R expression.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+Task id
 }
 }
 \if{html}{\out{<hr>}}
@@ -189,28 +244,6 @@ The key for the workflow and each individual report
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-submit"></a>}}
-\if{latex}{\out{\hypertarget{method-submit}{}}}
-\subsection{Method \code{submit()}}{
-Submit an arbitrary job on the queue
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{orderly_runner_$submit(job, environment = parent.frame())}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{job}}{A quoted R expression.}
-
-\item{\code{environment}}{Environment to run the expression in.}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-Task id
-}
-}
-\if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-status"></a>}}
 \if{latex}{\out{\hypertarget{method-status}{}}}
 \subsection{Method \code{status()}}{
@@ -231,6 +264,29 @@ Get the status of a job
 \subsection{Returns}{
 List containing the key, status, report_id (if available),
 output and the position of the job in the queue.
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-workflow_status"></a>}}
+\if{latex}{\out{\hypertarget{method-workflow_status}{}}}
+\subsection{Method \code{workflow_status()}}{
+Get the status of a workflow.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{orderly_runner_$workflow_status(workflow_key, output = FALSE)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{output}}{If TRUE include the output from each job in the workflow.}
+
+\item{\code{key}}{The workflow key.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+List containing the workflow_key, status and status of each
+job in the workflow.
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/server.Rd
+++ b/man/server.Rd
@@ -13,7 +13,8 @@ server(
   queue_id = NULL,
   workers = 1,
   backup_period = 600,
-  timeout_rate_limit = 2 * 60
+  timeout_rate_limit = 2 * 60,
+  log_level = "info"
 )
 }
 \arguments{
@@ -44,6 +45,8 @@ is skipped}
 
 \item{timeout_rate_limit}{How frequently should the API check for timeouts
 default 2 mins.}
+
+\item{log_level}{The "lgr" log level to use}
 }
 \description{
 Run orderly server

--- a/tests/testthat/helper-background.R
+++ b/tests/testthat/helper-background.R
@@ -54,8 +54,8 @@ orderly_server_background <- R6::R6Class(
           orderly.server::server(path, port, "127.0.0.1",
                                  timeout_rate_limit = 0)
         },
-        args = list(path = self$path, port = self$port)
-      )
+        args = list(path = self$path, port = self$port),
+        stdout = self$log, stderr = self$log)
 
       message("waiting for server to become responsive")
       wait_while(private$server_not_up)

--- a/tests/testthat/test-logging.R
+++ b/tests/testthat/test-logging.R
@@ -1,53 +1,15 @@
 context("logging")
 
-test_that("logging produces a message", {
-  expect_message(
-    api_log(sprintf("%s %s", "a", "b")),
-    "\\[[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\\] a b")
-  expect_message(
-    api_log("x"),
-    "\\[[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\\] x")
-})
+test_that("Can log verbosely", {
+  tmp <- tempfile()
+  on.exit(unlink(tmp))
+  logger <- make_logger("trace", tmp)
+  runner <- mock_runner()
+  api <- build_api(runner, "path", logger = logger)
+  res <- api$request("GET", "/")
+  lapply(readLines(tmp), jsonlite::fromJSON)
 
-test_that("log start includes request and path info", {
-  req <- list(REQUEST_METHOD = "GET", PATH_INFO = "/my/path")
-  expect_message(
-    api_log_start(NULL, req, NULL),
-    "\\[.+\\] GET /my/path")
-})
-
-test_that("log end includes code and response size", {
-  res <- list(status = 200, body = "a string")
-  value <- "something"
-  expect_message(
-    res <- api_log_end(NULL, NULL, res, value),
-    "\\[.+\\] `--> 200 \\(8 bytes\\)")
-  expect_identical(res, value)
-})
-
-test_that("log end includes code and response size for binary data", {
-  res <- list(status = 200, body = as.raw(sample(256) - 1))
-  value <- "something"
-  expect_message(
-    res <- api_log_end(NULL, NULL, res, value),
-    "\\[.+\\] `--> 200 \\(256 bytes\\)")
-  expect_identical(res, value)
-})
-
-test_that("log end handles errors", {
-  input_res <- list(status = 400, body = '{"errors":[
-                                            {"error": "RUN_FAILED",
-                                            "detail": "Failed to run report",
-                                            "trace": ["the", "trace"]}
-                                           ]}',
-              headers = list("Content-Type" = "application/json"))
-  value <- "something"
-  messages <- testthat::capture_messages(
-    res <- api_log_end(NULL, NULL, input_res, value))
-  expect_identical(res, value)
-  expect_match(messages[[1]], "\\[.+\\] error: RUN_FAILED")
-  expect_match(messages[[2]], "\\[.+\\] error-detail: Failed to run report")
-  expect_match(messages[[3]],
-               "\\[.+\\] error-trace: the\\n\\[.+\\] error-trace: trace")
-  expect_match(messages[[4]], "\\[.+\\] `--> 400 \\(274 bytes\\)")
+  dat <- jsonlite::stream_in(file(tmp), verbose = FALSE)
+  expect_equal(nrow(dat), 4)
+  expect_equal(dat$logger, rep("orderly.server", 4))
 })

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -72,9 +72,13 @@ test_that("run server", {
     list(path, allow_ref, queue_id = NULL, workers = 1))
 
   mockery::expect_called(mock_build_api, 1)
-  expect_equal(
-    mockery::mock_args(mock_build_api)[[1]],
-    list(runner, path, 600, rate_limit = 120))
+  args_build <- mockery::mock_args(mock_build_api)[[1]]
+  expect_length(args_build, 5)
+  expect_identical(args_build[[1]], runner)
+  expect_equal(args_build[[2]], path)
+  expect_equal(args_build$backup_period, 600)
+  expect_equal(args_build$rate_limit, 120)
+  expect_s3_class(args_build$logger, "Logger")
 
   mockery::expect_called(api$run, 1)
   expect_equal(

--- a/tests/testthat/test-z-integration.R
+++ b/tests/testthat/test-z-integration.R
@@ -149,7 +149,7 @@ test_that("git error returns valid json", {
 
 
 test_that("run report honours timeout", {
-  server <- start_test_server()
+  server <- start_test_server(log = "err.log")
   on.exit(server$stop())
 
   p <- file.path(server$path, "src", "count", "parameters.json")

--- a/tests/testthat/test-z-integration.R
+++ b/tests/testthat/test-z-integration.R
@@ -149,7 +149,7 @@ test_that("git error returns valid json", {
 
 
 test_that("run report honours timeout", {
-  server <- start_test_server(log = "err.log")
+  server <- start_test_server()
   on.exit(server$stop())
 
   p <- file.path(server$path, "src", "count", "parameters.json")


### PR DESCRIPTION
This PR enables logging as introduced in recent porcelain.

Typical logging will look like:

```
{"level":400,"timestamp":"2021-09-03 15:51:24","logger":"orderly.server","caller":"postserialize","msg":"response POST /v1/reports/count/run/ => 200 (129 bytes)"}
{"level":400,"timestamp":"2021-09-03 15:51:24","logger":"orderly.server","caller":"postroute","msg":"request GET /v1/reports/travelsick_llama/status/"}
{"level":400,"timestamp":"2021-09-03 15:51:24","logger":"orderly.server","caller":"postserialize","msg":"response GET /v1/reports/travelsick_llama/status/ => 200 (127 bytes)"}
{"level":400,"timestamp":"2021-09-03 15:51:24","logger":"orderly.server","caller":"postroute","msg":"request GET /v1/reports/travelsick_llama/status/"}
{"level":400,"timestamp":"2021-09-03 15:51:24","logger":"orderly.server","caller":"postserialize","msg":"response GET /v1/reports/travelsick_llama/status/ => 200 (127 bytes)"}
{"level":400,"timestamp":"2021-09-03 15:51:24","logger":"orderly.server","caller":"postroute","msg":"request GET /v1/reports/travelsick_llama/status/"}
{"level":400,"timestamp":"2021-09-03 15:51:24","logger":"orderly.server","caller":"postserialize","msg":"response GET /v1/reports/travelsick_llama/status/ => 200 (127 bytes)"}
```

there's still a bit of ordinary orderly logging that makes it through that we should consider looking at  as it will complicate processing very slightly.

Would be interesting to see how this looks in the context of a montagu/OW deploy before merging perhaps