### PR TITLE
Increase worker timeout

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -47,7 +47,8 @@ main_worker <- function(args = commandArgs(TRUE)) {
   # nocov start
   args <- main_worker_args(args)
   wait_for_go_signal(NULL, args$go_signal)
-  w <- rrq::rrq_worker_from_config(orderly_queue_id(args$queue_id, TRUE))
+  w <- rrq::rrq_worker_from_config(orderly_queue_id(args$queue_id, TRUE),
+                                   timeout = 30)
   w$loop()
   invisible(TRUE)
   # nocov end


### PR DESCRIPTION
Mark has seen this timing out on uat. Default timeout is 5s which I think is too short for everything to reliably be ready for workers to start.

```
$ ./start
Authenticating with the vault using 'github'
Pulling orderly-web images:
- css-generator (vimc/orderly-web-css-generator:release)
`-> sha256:62d15ad662
- migrate (vimc/orderlyweb-migrate:release)
`-> sha256:e2f44ae90e
- redis (redis:5.0)
`-> sha256:453965c6b9
- web (vimc/orderly-web:release)
`-> sha256:f5a87c1ab1
- admin (vimc/orderly-web-user-cli:release)
`-> sha256:d354032433
- orderly (vimc/montagu-orderly:master)
`-> sha256:5ecfbf2ba8
- orderly_worker (vimc/montagu-orderly:master)
`-> sha256:5ecfbf2ba8
Creating redis container
Creating orderly container
Configuring ssh
orderly volume already contains data - not initialising
Checking orderly schema is current
Writing orderly environment
Starting orderly server
Starting 1 orderly workers
Configuring ssh
Writing orderly environment
Starting worker orderly_web_orderly_worker_byqxtjmn
Generating custom css
Creating web container
Configuring web container
Migrating the web tables
Starting orderly server
Persisting configuration

$ docker ps -a
CONTAINER ID IMAGE COMMAND CREATED STATUS PORTS NAMES
40e07efa4740 vimc/orderly-web:release "/app/bin/app" 9 minutes ago Up 9 minutes orderly_web_web
51a74ced2532 vimc/montagu-orderly:master "/usr/local/bin/orde…" 9 minutes ago Exited (1) 9 minutes ago orderly_web_orderly_worker_dymthwvk
2ed0f29c9241 vimc/montagu-orderly:master "/usr/local/bin/orde…" 9 minutes ago Up 9 minutes 8321/tcp orderly_web_orderly
39a372eb3db7 redis:5.0 "docker-entrypoint.s…" 9 minutes ago Up 9 minutes 6379/tcp orderly_web_redis

$ docker logs orderly_web_orderly_worker_dymthwvk
Waiting for go signal at '/go_signal'
Recieved go signal after 2 secs
Invalid rrq worker configuration key 'localhost'
Invalid rrq worker configuration key 'localhost'
Invalid rrq worker configuration key 'localhost'
Invalid rrq worker configuration key 'localhost'
Invalid rrq worker configuration key 'localhost'
Error in worker_config_read(con, keys, worker_config) :
Timeout: config not readable in time
Invalid rrq worker configuration key 'localhost'
Calls: <Anonymous> ... tryCatch -> tryCatchList -> tryCatchOne -> <Anonymous>
Execution halted
```