### PR TITLE
Update tests to work with updated orderly_git_example

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Imports:
     ids,
     jsonlite,
     lgr,
-    orderly (>= 1.3.7),
+    orderly (>= 1.4.4),
     porcelain (>= 0.1.4),
     processx,
     redux,
@@ -35,4 +35,4 @@ Encoding: UTF-8
 Remotes:
     reside-ic/porcelain,
     ropensci/jsonvalidate,
-    vimc/orderly
+    vimc/orderly@vimc-4977

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,4 +35,4 @@ Encoding: UTF-8
 Remotes:
     reside-ic/porcelain,
     ropensci/jsonvalidate,
-    vimc/orderly@vimc-4977
+    vimc/orderly

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly.server
 Title: Serve Orderly
-Version: 0.3.19
+Version: 0.3.20
 Description: Run orderly reports as a server.
 License: MIT + file LICENSE
 Author: Rich FitzJohn

--- a/tests/testthat/test-git.R
+++ b/tests/testthat/test-git.R
@@ -278,7 +278,7 @@ test_that("get_reports only shows one sided changes", {
   other_commits <- git_commits("other", path[["local"]])
   expect_equal(nrow(other_commits), 1)
   other_reports <- get_reports("other", other_commits$id, path[["local"]])
-  expect_equal("other" %in% other_reports)
+  expect_true("other" %in% other_reports)
 })
 
 test_that("can get parameters from a report", {

--- a/tests/testthat/test-git.R
+++ b/tests/testthat/test-git.R
@@ -202,7 +202,7 @@ test_that("can get report list from git", {
   other_commits <- git_commits("other", path[["local"]])
   expect_equal(nrow(other_commits), 1)
   other_reports <- get_reports("other", other_commits$id, path[["local"]])
-  expect_equal(other_reports, "other")
+  expect_true("other" %in% other_reports)
 
   ## git_commits works with NULL branch and commit
   default_reports <- get_reports(NULL, NULL, path[["local"]])
@@ -227,7 +227,7 @@ test_that("report only shows when pushed to remote", {
   other_commits <- git_commits("other", path[["local"]])
   expect_equal(nrow(other_commits), 1)
   other_reports <- get_reports("other", other_commits$id, path[["local"]])
-  expect_equal(other_reports, "other")
+  expect_true("other" %in% other_reports)
 
   ## Push to remote
   invisible(git_run(c("push", "--set-upstream origin other"),
@@ -236,7 +236,7 @@ test_that("report only shows when pushed to remote", {
   other_commits <- git_commits("other", path[["local"]])
   expect_equal(nrow(other_commits), 2)
   other_reports <- get_reports("other", other_commits$id[[1]], path[["local"]])
-  expect_equal(other_reports, c("new-report", "other"))
+  expect_true(all(c("other", "new-report") %in% other_reports))
 })
 
 test_that("get_reports only shows one sided changes", {

--- a/tests/testthat/test-git.R
+++ b/tests/testthat/test-git.R
@@ -278,7 +278,7 @@ test_that("get_reports only shows one sided changes", {
   other_commits <- git_commits("other", path[["local"]])
   expect_equal(nrow(other_commits), 1)
   other_reports <- get_reports("other", other_commits$id, path[["local"]])
-  expect_equal(other_reports, "other")
+  expect_equal("other" %in% other_reports)
 })
 
 test_that("can get parameters from a report", {

--- a/tests/testthat/test-z-integration.R
+++ b/tests/testthat/test-z-integration.R
@@ -344,7 +344,7 @@ test_that("can get available reports", {
   url <- paste0("/reports/source?branch=other&commit=", other_r$data[[1]]$id)
   other_reports <- content(httr::GET(server$api_url(url)))
   expect_equal(other_reports$status, "success")
-  expect_equal(other_reports$data, "other")
+  expect_true("other" %in% other_reports$data)
 })
 
 test_that("can get available reports without parameters", {


### PR DESCRIPTION
We've made a change to orderly https://github.com/vimc/orderly/pull/306 to include additional reports in the demo `git` dir on the `other` branch. This PR updates tests which were checking the reports on that branch.

Should merge this after https://github.com/vimc/orderly/pull/306 and remove the branch pin