### PR TITLE
Fix issue where workflow summary was not reporting back params

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly.server
 Title: Serve Orderly
-Version: 0.3.21
+Version: 0.3.22
 Description: Run orderly reports as a server.
 License: MIT + file LICENSE
 Author: Rich FitzJohn

--- a/R/api.R
+++ b/R/api.R
@@ -380,7 +380,8 @@ target_workflow_summary <- function(runner, body) {
   if (!is.null(body$ref)) {
     runner$assert_ref_switching_allowed(body$ref)
   }
-  workflow_summary(runner$root, body$reports, body$ref)
+  summary <- workflow_summary(runner$root, body$reports, body$ref)
+  serialize_workflow_summary(summary)
 }
 
 endpoint_workflow_summary <- function(runner) {

--- a/R/workflows.R
+++ b/R/workflows.R
@@ -167,7 +167,7 @@ serialize_workflow <- function(workflow) {
       name = scalar(single_report$name)
     )
     item$instance <- scalar(single_report$instance)
-    item$parameters <- recursive_scalar(single_report$parameters)
+    item$params <- recursive_scalar(single_report$params)
     item$depends_on <- single_report$depends_on
     item
   })

--- a/R/workflows.R
+++ b/R/workflows.R
@@ -25,9 +25,8 @@ workflow_summary <- function(path, reports, ref = NULL) {
   dependencies <- orderly_upstream_dependencies(report_names, root = path,
                                                 ref = ref)
   list(
-    reports = serialize_workflow(
-      construct_workflow(reports, report_names, dependencies)),
-    ref = scalar(ref),
+    reports = construct_workflow(reports, report_names, dependencies),
+    ref = ref,
     missing_dependencies = missing_dependencies(report_names, dependencies)
   )
 }
@@ -48,11 +47,10 @@ workflow_summary <- function(path, reports, ref = NULL) {
 missing_dependencies <- function(report_names, dependencies) {
   missing_deps <- lapply(report_names, function(report) {
     report_deps <- dependencies[[report]]
-    if (is.null(report_deps)) {
+    if (is.null(report_deps) || all(report_deps %in% report_names)) {
       return(list())
     }
-    recursive_scalar(
-      report_deps[!(report_deps %in% report_names)])
+    as.list(report_deps[!(report_deps %in% report_names)])
   })
   stats::setNames(missing_deps, report_names)
 }
@@ -158,11 +156,11 @@ workflow_combine_status <- function(report_status) {
   workflow_status
 }
 
-## Has format matching WorkflowReports schema
+## Has format matching WorkflowSummaryResponse schema
 ## but we need to be careful with tagging items as scalar so it
 ## serializes properly
-serialize_workflow <- function(workflow) {
-  lapply(workflow, function(single_report) {
+serialize_workflow_summary <- function(workflow) {
+  serialize_report <- function(single_report) {
     item <- list(
       name = scalar(single_report$name)
     )
@@ -170,5 +168,11 @@ serialize_workflow <- function(workflow) {
     item$params <- recursive_scalar(single_report$params)
     item$depends_on <- single_report$depends_on
     item
-  })
+  }
+
+  list(
+    reports = lapply(workflow$reports, serialize_report),
+    ref = scalar(workflow$ref),
+    missing_dependencies = recursive_scalar(workflow$missing_dependencies)
+  )
 }

--- a/tests/testthat/test-api-workflows.R
+++ b/tests/testthat/test-api-workflows.R
@@ -30,41 +30,66 @@ test_that("can get workflow summary", {
     ref = scalar(ref)
   )), t)
 
-  output <- list(
+  workflow <- list(
     reports = list(
       list(
-        name = scalar("preprocess"),
-        instance = scalar("production"),
+        name = "preprocess",
+        instance = "production",
         params = list(
-          nmin = scalar(0.5),
-          nmax = scalar(2)
+          nmin = 0.5,
+          nmax = 2
         ),
-        depends_on = list()
+        depends_on = c()
       ),
       list(
-        name = scalar("process"),
-        instance = scalar("production"),
-        depends_on = list(scalar("preprocess"))
+        name = "process",
+        instance = "production",
+        depends_on = c("preprocess")
       ),
       list(
-        name = scalar("postprocess"),
-        instance = scalar("production"),
-        depends_on = list(scalar("preprocess"), scalar("process"))
+        name = "postprocess",
+        instance = "production",
+        depends_on = c("preprocess", "process")
       )
     ),
-    ref = scalar("123"),
+    ref = "123",
     missing_dependencies = list(
-      preprocess = "",
-      process = "",
-      postprocess = ""
+      preprocess = list(),
+      process = list(),
+      postprocess = list()
     )
   )
-  mock_workflow_summary <- mockery::mock(output, cycle = TRUE)
+  mock_workflow_summary <- mockery::mock(workflow, cycle = TRUE)
   with_mock("orderly.server:::workflow_summary" = mock_workflow_summary, {
     res <- target_workflow_summary(runner, t)
   })
   mockery::expect_called(mock_workflow_summary, 1)
-  expect_equal(res, output)
+  expect_equal(res$reports, list(
+    list(
+      name = scalar("preprocess"),
+      instance = scalar("production"),
+      params = list(
+        nmin = scalar(0.5),
+        nmax = scalar(2)
+      )
+    ),
+    list(
+      name = scalar("process"),
+      instance = scalar("production"),
+      depends_on = c("preprocess")
+    ),
+    list(
+      name = scalar("postprocess"),
+      instance = scalar("production"),
+      depends_on = c("preprocess", "process")
+    )
+  ))
+  expect_equal(res$ref, scalar("123"))
+  expect_equal(res$missing_dependencies, list(
+    preprocess = list(),
+    process = list(),
+    postprocess = list()
+  ))
 
   ## endpoint
   with_mock("orderly.server:::workflow_summary" = mock_workflow_summary, {

--- a/tests/testthat/test-workflows.R
+++ b/tests/testthat/test-workflows.R
@@ -142,13 +142,13 @@ test_that("workflow summary returns ref, instance and parameters", {
   reports <- list(
     list(name = "depend4",
          instance = "production",
-         parameters = list(nmin = 0.5, another_param = "test"))
+         params = list(nmin = 0.5, another_param = "test"))
   )
   expect_equal(workflow_summary(path, reports, commits$id),
                list(reports = list(
                  list(name = scalar("depend4"),
                       instance = scalar("production"),
-                      parameters = list(
+                      params = list(
                         nmin = scalar(0.5),
                         another_param = scalar("test")
                       ))

--- a/tests/testthat/test-workflows.R
+++ b/tests/testthat/test-workflows.R
@@ -18,7 +18,7 @@ test_that("can get summary of a workflow", {
   )
   expect_equal(workflow_summary(path, reports),
                list(reports = list(
-                 list(name = scalar("other"))
+                 list(name = "other")
                ),
                ref = NULL,
                missing_dependencies = list(
@@ -30,11 +30,11 @@ test_that("can get summary of a workflow", {
   )
   expect_equal(workflow_summary(path, reports),
                list(reports = list(
-                  list(name = scalar("use_dependency"))
+                  list(name = "use_dependency")
                 ),
                 ref = NULL,
                 missing_dependencies = list(
-                 use_dependency = list(scalar("other"))
+                 use_dependency = list("other")
                )))
 
   reports <- list(
@@ -43,8 +43,8 @@ test_that("can get summary of a workflow", {
   )
   expect_equal(workflow_summary(path, reports),
                list(reports = list(
-                 list(name = scalar("other")),
-                 list(name = scalar("use_dependency"),
+                 list(name = "other"),
+                 list(name = "use_dependency",
                       depends_on = "other")
                ),
                ref = NULL,
@@ -62,11 +62,11 @@ test_that("workflow summary only looks at depth 1 dependencies", {
   expect_equal(workflow_summary(path, reports),
                list(
                  reports = list(
-                   list(name = scalar("use_dependency_2"))
+                   list(name = "use_dependency_2")
                  ),
                  ref = NULL,
                  missing_dependencies = list(
-                 use_dependency_2 = list(scalar("use_dependency"))
+                 use_dependency_2 = list("use_dependency")
                )))
 })
 
@@ -78,11 +78,11 @@ test_that("workflow summary can handle multiple dependencies", {
   )
   expect_equal(workflow_summary(path, reports),
                list(reports = list(
-                 list(name = scalar("depend4"))
+                 list(name = "depend4")
                ),
                ref = NULL,
                missing_dependencies = list(
-                 depend4 = list(scalar("example"), scalar("depend2")))
+                 depend4 = list("example", "depend2"))
                ))
 
   reports <- list(
@@ -91,14 +91,14 @@ test_that("workflow summary can handle multiple dependencies", {
   )
   expect_equal(workflow_summary(path, reports),
                list(reports = list(
-                 list(name = scalar("depend2")),
-                 list(name = scalar("depend4"),
+                 list(name = "depend2"),
+                 list(name = "depend4",
                       depends_on = "depend2")
                ),
                ref = NULL,
                missing_dependencies = list(
-                 depend4 = list(scalar("example")),
-                 depend2 =  list(scalar("example")))
+                 depend4 = list("example"),
+                 depend2 =  list("example"))
                ))
 
   reports <- list(
@@ -108,10 +108,10 @@ test_that("workflow summary can handle multiple dependencies", {
   )
   expect_equal(workflow_summary(path, reports),
                list(reports = list(
-                 list(name = scalar("example")),
-                 list(name = scalar("depend2"),
+                 list(name = "example"),
+                 list(name = "depend2",
                       depends_on = "example"),
-                 list(name = scalar("depend4"),
+                 list(name = "depend4",
                       depends_on = c("depend2", "example"))
                ),
                ref = NULL,
@@ -127,11 +127,11 @@ test_that("workflow summary can handle multiple dependencies", {
   )
   expect_equal(workflow_summary(path, reports),
                list(reports = list(
-                 list(name = scalar("depend2"))
+                 list(name = "depend2")
                ),
                ref = NULL,
                missing_dependencies = list(
-                 depend2 = list(scalar("example"))
+                 depend2 = list("example")
                )))
 })
 
@@ -146,16 +146,16 @@ test_that("workflow summary returns ref, instance and parameters", {
   )
   expect_equal(workflow_summary(path, reports, commits$id),
                list(reports = list(
-                 list(name = scalar("depend4"),
-                      instance = scalar("production"),
+                 list(name = "depend4",
+                      instance = "production",
                       params = list(
-                        nmin = scalar(0.5),
-                        another_param = scalar("test")
+                        nmin = 0.5,
+                        another_param = "test"
                       ))
                ),
-               ref = scalar(commits$id),
+               ref = commits$id,
                missing_dependencies = list(
-                 depend4 = list(scalar("example"), scalar("depend2")))
+                 depend4 = list("example", "depend2"))
                ))
 })
 

--- a/tests/testthat/test-z-integration.R
+++ b/tests/testthat/test-z-integration.R
@@ -543,6 +543,12 @@ test_that("can get missing dependencies of a workflow", {
                     list(
                       name = scalar("depend"),
                       instance = scalar("production")
+                    ),
+                    list(
+                      name = scalar("count_param"),
+                      params = list(
+                        time = scalar(1)
+                      )
                     )
                   ),
                   ref = scalar(sha)),
@@ -554,11 +560,18 @@ test_that("can get missing dependencies of a workflow", {
   expect_equal(dat$data, list(
     reports = list(
       list(name = "depend",
-           instance = "production")
+           instance = "production"),
+      list(
+        name = "count_param",
+        params = list(
+          time = 1
+        )
+      )
     ),
     ref = sha,
     missing_dependencies = list(
-      depend = "example"
+      depend = "example",
+      count_param = list()
     )
   ))
 })


### PR DESCRIPTION
Bug seen by @LekanAnni - this was because the code was using `parameters` instead of `params` oops.. 
An example of being bitten by lots of mock tests and our integration test not catching it.