### PR TITLE
Fix no of reports in response increasing when running the same report multiple times

### DIFF
--- a/R/workflows.R
+++ b/R/workflows.R
@@ -20,8 +20,8 @@
 ##'
 ##' @keywords internal
 workflow_summary <- function(path, reports, ref = NULL) {
-  report_names <- vcapply(reports, function(report) report$name,
-                          USE.NAMES = FALSE)
+  report_names <- unique(vcapply(reports, function(report) report$name,
+                                 USE.NAMES = FALSE))
   dependencies <- orderly_upstream_dependencies(report_names, root = path,
                                                 ref = ref)
   list(
@@ -91,7 +91,6 @@ build_workflow <- function(root, reports, ref) {
 construct_workflow <- function(reports, report_names, dependencies) {
   dependencies_graph <- workflow_dependencies(report_names, dependencies)
   order <- topological_sort(dependencies_graph)
-  report_names <- vcapply(reports, "[[", "name")
   build_item <- function(report_name) {
     ## There may be multiple reports due to be run with this name
     report_details <- reports[report_name == report_names]

--- a/R/workflows.R
+++ b/R/workflows.R
@@ -20,14 +20,17 @@
 ##'
 ##' @keywords internal
 workflow_summary <- function(path, reports, ref = NULL) {
-  report_names <- unique(vcapply(reports, function(report) report$name,
-                                 USE.NAMES = FALSE))
+  all_reports <- vcapply(reports, function(report) report$name,
+                         USE.NAMES = FALSE)
+  report_names <- unique(all_reports)
   dependencies <- orderly_upstream_dependencies(report_names, root = path,
                                                 ref = ref)
+  missing <- missing_dependencies(report_names, dependencies)
+
   list(
     reports = construct_workflow(reports, report_names, dependencies),
     ref = ref,
-    missing_dependencies = missing_dependencies(report_names, dependencies)
+    missing_dependencies = missing[all_reports]
   )
 }
 

--- a/tests/testthat/test-workflows.R
+++ b/tests/testthat/test-workflows.R
@@ -586,6 +586,8 @@ test_that("orderly workflow works with running a report twice", {
     list(name = "depend4",
          params = list(nmin = 0.5, another_param = "test")),
     list(name = "depend4",
+         params = list(nmin = 0.5, another_param = "test")),
+    list(name = "depend4",
          params = list(nmin = 1, another_param = "test"))
   )
 
@@ -593,6 +595,8 @@ test_that("orderly workflow works with running a report twice", {
   expect_equal(summary$reports, reports)
   expect_equal(summary$ref, "master")
   expect_equal(summary$missing_dependencies, list(
+    depend4 = list("example", "depend2"),
+    depend4 = list("example", "depend2"),
     depend4 = list("example", "depend2")
   ))
 })

--- a/tests/testthat/test-workflows.R
+++ b/tests/testthat/test-workflows.R
@@ -589,6 +589,10 @@ test_that("orderly workflow works with running a report twice", {
          params = list(nmin = 1, another_param = "test"))
   )
 
-  summary <- workflow_summary(path, reports, NULL)
-  expect_equal(length(summary$reports), 2)
+  summary <- workflow_summary(path, reports, "master")
+  expect_equal(summary$reports, reports)
+  expect_equal(summary$ref, "master")
+  expect_equal(summary$missing_dependencies, list(
+    depend4 = list("example", "depend2")
+  ))
 })

--- a/tests/testthat/test-workflows.R
+++ b/tests/testthat/test-workflows.R
@@ -577,3 +577,18 @@ test_that("can get upstream dependencies", {
     depend2 = "example"
   ))
 })
+
+test_that("orderly workflow works with running a report twice", {
+  path <- orderly_prepare_orderly_example("depends", testing = TRUE, git = TRUE)
+  commits <- git_commits(branch = "master", root = path)
+
+  reports <- list(
+    list(name = "depend4",
+         params = list(nmin = 0.5, another_param = "test")),
+    list(name = "depend4",
+         params = list(nmin = 1, another_param = "test"))
+  )
+
+  summary <- workflow_summary(path, reports, NULL)
+  expect_equal(length(summary$reports), 2)
+})


### PR DESCRIPTION
We have a bug atm where if we run the same report multiple times in a workflow e.g. with different params it will copy the reports in the response that number of times. So e.g. if running other twice it was returning 4 reports instead of the 2 expected.