### PR TITLE
mrc-2900 bug in returned order of reports for workflow summary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .Rhistory
 .RData
 orderly
+.idea

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,6 +18,7 @@ Imports:
     processx,
     redux,
     rrq (>= 0.5.0),
+    utils,
     webutils,
     yaml,
     zip

--- a/R/workflows.R
+++ b/R/workflows.R
@@ -126,11 +126,6 @@ topological_sort <- function(graph) {
 
   while (any(!explored)) {
     if (length(stack) > 1 && head(stack, n = 1) == tail(stack, n = 1)) {
-      f <- function(i) {
-        sprintf("  %s: depends on %s",
-                names(graph)[[i]], paste(graph[[i]], collapse = ", "))
-      }
-
       stack <- rev(stack)
       node <- stack[1]
       nodes <- node
@@ -139,30 +134,34 @@ topological_sort <- function(graph) {
         children <- which(report_names %in% graph[[node]])
         index <- seq_along(children)
         stack <- stack[-index]
-        node <- head(children, n = 1)
+        node <- children[1]
         nodes <- c(nodes, node)
       }
+
+      f <- function(i) {
+        sprintf("  %s: depends on %s",
+                names(graph)[[i]], paste(graph[[i]], collapse = ", "))
+      }
+
       detail <- paste(vcapply(nodes, f), collapse = "\n")
       stop(sprintf("A cyclic dependency detected for %s:\n%s",
                    paste(names(graph)[nodes], collapse = ", "), detail))
     }
 
-    i <- head(stack, n = 1)
+    i <- stack[1]
     if (!explored[i]) {
       if (length(deps[[i]]) == 0 || all(explored[deps[[i]]])) {
         graph_sorted <- c(graph_sorted, i)
         explored[i] <- TRUE
         stack <- stack[-1]
-      }
-      else {
+      } else {
         stack <- c(which(report_names %in% graph[[i]]), stack)
       }
-    }
-    else {
+    } else {
       stack <- stack[-1]
     }
     if (length(stack) == 0) {
-      stack <- head(which(!explored), n = 1)
+      stack <- which(!explored)[1]
     }
   }
   names(graph)[graph_sorted]

--- a/R/workflows.R
+++ b/R/workflows.R
@@ -65,6 +65,7 @@ missing_dependencies <- function(report_names, dependencies) {
 ## > - reportD = c(reportA, reportB)
 ## means A & C have no dependencies, B depends on C, D depends on A & B
 workflow_dependencies <- function(report_names, dependencies) {
+
   get_present_dependencies <- function(report) {
     present_deps <- report_names[report_names %in% dependencies[[report]]]
     if (length(present_deps) == 0) {
@@ -72,6 +73,7 @@ workflow_dependencies <- function(report_names, dependencies) {
     }
     present_deps
   }
+
   deps_graph <- lapply(report_names, get_present_dependencies)
   names(deps_graph) <- report_names
   deps_graph
@@ -94,9 +96,11 @@ build_workflow <- function(root, reports, ref) {
 construct_workflow <- function(reports, report_names, dependencies) {
   dependencies_graph <- workflow_dependencies(report_names, dependencies)
   order <- topological_sort(dependencies_graph)
+  all_report_names <- vcapply(reports, function(report) report$name)
+
   build_item <- function(report_name) {
     ## There may be multiple reports due to be run with this name
-    report_details <- reports[report_name == report_names]
+    report_details <- reports[report_name == all_report_names]
     lapply(report_details, function(report_detail) {
       deps <- dependencies_graph[[report_name]]
       if (length(deps) == 0 || all(is.na(deps))) {
@@ -106,6 +110,7 @@ construct_workflow <- function(reports, report_names, dependencies) {
       report_detail
     })
   }
+
   workflow <- lapply(order, build_item)
   unlist(workflow, recursive = FALSE, use.names = FALSE)
 }
@@ -162,6 +167,7 @@ workflow_combine_status <- function(report_status) {
 ## but we need to be careful with tagging items as scalar so it
 ## serializes properly
 serialize_workflow_summary <- function(workflow) {
+
   serialize_report <- function(single_report) {
     item <- list(
       name = scalar(single_report$name)

--- a/tests/testthat/test-workflows.R
+++ b/tests/testthat/test-workflows.R
@@ -1,6 +1,5 @@
 context("workflows")
 
-
 test_that("workflow summary errors if report not found", {
   path <- orderly_prepare_orderly_example("minimal", git = TRUE)
   reports <- list(
@@ -20,22 +19,22 @@ test_that("can get summary of a workflow", {
                list(reports = list(
                  list(name = "other")
                ),
-               ref = NULL,
-               missing_dependencies = list(
-                 other = list()
-               )))
+                    ref = NULL,
+                    missing_dependencies = list(
+                      other = list()
+                    )))
 
   reports <- list(
     list(name = "use_dependency")
   )
   expect_equal(workflow_summary(path, reports),
                list(reports = list(
-                  list(name = "use_dependency")
-                ),
-                ref = NULL,
-                missing_dependencies = list(
-                 use_dependency = list("other")
-               )))
+                 list(name = "use_dependency")
+               ),
+                    ref = NULL,
+                    missing_dependencies = list(
+                      use_dependency = list("other")
+                    )))
 
   reports <- list(
     list(name = "use_dependency"),
@@ -47,11 +46,113 @@ test_that("can get summary of a workflow", {
                  list(name = "use_dependency",
                       depends_on = "other")
                ),
-               ref = NULL,
-               missing_dependencies = list(
-                 use_dependency = list(),
-                 other = list()
-               )))
+                    ref = NULL,
+                    missing_dependencies = list(
+                      use_dependency = list(),
+                      other = list()
+                    )))
+})
+
+test_that("workflow summary can handle multiple instances of the same report", {
+  path <- orderly_prepare_orderly_example("demo", git = TRUE)
+  reports <- list(
+    list(name = "other", params = list(
+      nmin = 0.5
+    )),
+    list(name = "global"),
+    list(name = "other", params = list(
+      nmin = 1
+    )),
+    list(name = "connection")
+  )
+
+  # original order here is considered to be "other", "global", "connection"
+  # the second "other" report is grouped with the first
+  expect_equal(workflow_summary(path, reports),
+               list(
+                 reports = list(
+                   list(name = "other",
+                        params = list(
+                          nmin = 0.5
+                        )),
+                   list(name = "other",
+                        params = list(
+                          nmin = 1
+                        )),
+                   list(name = "global"),
+                   list(name = "connection")
+                 ),
+                 ref = NULL,
+                 missing_dependencies = list(other = list(),
+                                             global = list(),
+                                             other = list(),
+                                             connection = list())))
+})
+
+test_that("workflow summary can handle mutiple instances and dependencies", {
+  path <- orderly_prepare_orderly_example("depends", testing = TRUE, git = TRUE)
+  reports <- list(
+    list(name = "other", params = list(
+      nmin = 0.5
+    )),
+    list(name = "global"),
+    list(name = "depend4",
+         params = list(nmin = 0.5)),
+    list(name = "other", params = list(
+      nmin = 1
+    )),
+    list(name = "depend2",
+         params = list(nmin = 0.5)),
+    list(name = "depend4",
+         params = list(nmin = 2)),
+    list(name = "depend2",
+         params = list(nmin = 2)),
+    list(name = "connection")
+  )
+
+  # original order here is considered to be "other", "global", "depend4", "connection"
+  # the second "other" report is grouped with the first and the second "depend4" is grouped with the first
+  expect_equal(s <- workflow_summary(path, reports),
+               list(
+                 reports = list(
+                   list(name = "other",
+                        params = list(
+                          nmin = 0.5
+                        )),
+                   list(name = "other",
+                        params = list(
+                          nmin = 1
+                        )),
+                   list(name = "global"),
+                   list(name = "depend2",
+                        params = list(
+                          nmin = 0.5
+                        )),
+                   list(name = "depend2",
+                        params = list(
+                          nmin = 2
+                        )),
+                   list(name = "connection"),
+                   list(name = "depend4",
+                        params = list(
+                          nmin = 0.5
+                        ),
+                        depends_on = "depend2"),
+                   list(name = "depend4",
+                        params = list(
+                          nmin = 2
+                        ),
+                        depends_on = "depend2")
+                 ),
+                 ref = NULL,
+                 missing_dependencies = list(other = list(),
+                                             global = list(),
+                                             depend4 = list("example"),
+                                             other = list(),
+                                             depend2 = list("example"),
+                                             depend4 = list("example"),
+                                             depend2 = list("example"),
+                                             connection = list())))
 })
 
 test_that("workflow summary only looks at depth 1 dependencies", {
@@ -66,8 +167,8 @@ test_that("workflow summary only looks at depth 1 dependencies", {
                  ),
                  ref = NULL,
                  missing_dependencies = list(
-                 use_dependency_2 = list("use_dependency")
-               )))
+                   use_dependency_2 = list("use_dependency")
+                 )))
 })
 
 test_that("workflow summary can handle multiple dependencies", {
@@ -80,9 +181,9 @@ test_that("workflow summary can handle multiple dependencies", {
                list(reports = list(
                  list(name = "depend4")
                ),
-               ref = NULL,
-               missing_dependencies = list(
-                 depend4 = list("example", "depend2"))
+                    ref = NULL,
+                    missing_dependencies = list(
+                      depend4 = list("example", "depend2"))
                ))
 
   reports <- list(
@@ -95,10 +196,10 @@ test_that("workflow summary can handle multiple dependencies", {
                  list(name = "depend4",
                       depends_on = "depend2")
                ),
-               ref = NULL,
-               missing_dependencies = list(
-                 depend4 = list("example"),
-                 depend2 =  list("example"))
+                    ref = NULL,
+                    missing_dependencies = list(
+                      depend4 = list("example"),
+                      depend2 = list("example"))
                ))
 
   reports <- list(
@@ -114,11 +215,11 @@ test_that("workflow summary can handle multiple dependencies", {
                  list(name = "depend4",
                       depends_on = c("depend2", "example"))
                ),
-               ref = NULL,
-               missing_dependencies = list(
-                 depend4 = list(),
-                 depend2 = list(),
-                 example =  list())
+                    ref = NULL,
+                    missing_dependencies = list(
+                      depend4 = list(),
+                      depend2 = list(),
+                      example = list())
                ))
 
 
@@ -129,10 +230,10 @@ test_that("workflow summary can handle multiple dependencies", {
                list(reports = list(
                  list(name = "depend2")
                ),
-               ref = NULL,
-               missing_dependencies = list(
-                 depend2 = list("example")
-               )))
+                    ref = NULL,
+                    missing_dependencies = list(
+                      depend2 = list("example")
+                    )))
 })
 
 test_that("workflow summary returns ref, instance and parameters", {
@@ -153,9 +254,9 @@ test_that("workflow summary returns ref, instance and parameters", {
                         another_param = "test"
                       ))
                ),
-               ref = commits$id,
-               missing_dependencies = list(
-                 depend4 = list("example", "depend2"))
+                    ref = commits$id,
+                    missing_dependencies = list(
+                      depend4 = list("example", "depend2"))
                ))
 })
 
@@ -192,7 +293,7 @@ test_that("can work out dependencies graph", {
                     depend4 = c("example", "depend2")))
 })
 
-test_that("sorting can be retrieved", {
+test_that("can topological sort", {
   graph <- list(b = NA,
                 e = "k",
                 k = c("b", "i", "j"),
@@ -204,6 +305,41 @@ test_that("sorting can be retrieved", {
   sort <- topological_sort(graph)
   expect_equal(sort,
                c("b", "i", "j", "k", "h", "e", "g", "c"))
+})
+
+test_that("sort preserves original order if no dependencies", {
+  graph <- list(b = NA,
+                e = NA,
+                f = NA)
+  sort <- topological_sort(graph)
+  expect_equal(sort,
+               c("b", "e", "f"))
+
+  graph <- list(b = c("e", "k"),
+                e = NA,
+                f = NA,
+                k = NA)
+  sort <- topological_sort(graph)
+  expect_equal(sort,
+               c("e", "f", "k", "b"))
+
+  graph <- list(b = NA,
+                e = NA,
+                f = "k",
+                k = NA,
+                g = NA)
+  sort <- topological_sort(graph)
+  expect_equal(sort,
+               c("b", "e", "k", "g", "f"))
+})
+
+test_that("sort preserves original order if valid", {
+  graph <- list(b = NA,
+                e = "b",
+                k = c("e", "b"))
+  sort <- topological_sort(graph)
+  expect_equal(sort,
+               c("b", "e", "k"))
 })
 
 test_that("cycled can be detected", {
@@ -453,7 +589,7 @@ test_that("dependencies are resolved using git ref", {
 
   ## Remove dependencies on branch
   prev <- git_checkout_branch("test", root = runner$root, create = TRUE)
-  depend4_path <- file.path(runner$root,  "src/depend4/orderly.yml")
+  depend4_path <- file.path(runner$root, "src/depend4/orderly.yml")
   writeLines(c("script: script.R",
                "artefacts:",
                "  staticgraph:",

--- a/tests/testthat/test-workflows.R
+++ b/tests/testthat/test-workflows.R
@@ -132,7 +132,6 @@ test_that("workflow summary can handle mutiple instances and dependencies", {
                         params = list(
                           nmin = 2
                         )),
-                   list(name = "connection"),
                    list(name = "depend4",
                         params = list(
                           nmin = 0.5
@@ -142,7 +141,8 @@ test_that("workflow summary can handle mutiple instances and dependencies", {
                         params = list(
                           nmin = 2
                         ),
-                        depends_on = "depend2")
+                        depends_on = "depend2"),
+                   list(name = "connection")
                  ),
                  ref = NULL,
                  missing_dependencies = list(other = list(),
@@ -304,7 +304,7 @@ test_that("can topological sort", {
                 c = c("j", "h"))
   sort <- topological_sort(graph)
   expect_equal(sort,
-               c("b", "i", "j", "k", "h", "e", "g", "c"))
+               c("b", "i", "j", "k", "e", "h", "g", "c"))
 })
 
 test_that("sort preserves original order if no dependencies", {
@@ -321,7 +321,7 @@ test_that("sort preserves original order if no dependencies", {
                 k = NA)
   sort <- topological_sort(graph)
   expect_equal(sort,
-               c("e", "f", "k", "b"))
+               c("e", "k", "b", "f"))
 
   graph <- list(b = NA,
                 e = NA,
@@ -330,7 +330,7 @@ test_that("sort preserves original order if no dependencies", {
                 g = NA)
   sort <- topological_sort(graph)
   expect_equal(sort,
-               c("b", "e", "k", "g", "f"))
+               c("b", "e", "k", "f", "g"))
 })
 
 test_that("sort preserves original order if valid", {
@@ -358,6 +358,7 @@ test_that("cycled can be detected", {
   a: depends on b, c
   b: depends on c
   c: depends on a", fixed = TRUE)
+
 })
 
 test_that("workflow representation can be built", {

--- a/tests/testthat/test-workflows.R
+++ b/tests/testthat/test-workflows.R
@@ -26,29 +26,30 @@ test_that("can get summary of a workflow", {
     list(name = "use_dependency")
   )
   expect_equal(workflow_summary(path, reports),
-               list(reports = list(
-                 list(name = "use_dependency")
-               ),
-                    ref = NULL,
-                    missing_dependencies = list(
-                      use_dependency = list("other")
-                    )))
+               list(
+                 reports = list(
+                   list(name = "use_dependency")
+                 ),
+                 ref = NULL,
+                 missing_dependencies = list(
+                   use_dependency = list("other")
+                 )))
 
   reports <- list(
     list(name = "use_dependency"),
     list(name = "other")
   )
   expect_equal(workflow_summary(path, reports),
-               list(reports = list(
-                 list(name = "other"),
-                 list(name = "use_dependency",
-                      depends_on = "other")
-               ),
-                    ref = NULL,
-                    missing_dependencies = list(
-                      use_dependency = list(),
-                      other = list()
-                    )))
+               list(
+                 reports = list(
+                   list(name = "other"),
+                   list(name = "use_dependency",
+                        depends_on = "other")),
+                 ref = NULL,
+                 missing_dependencies = list(
+                   use_dependency = list(),
+                   other = list()
+                 )))
 })
 
 test_that("workflow summary can handle multiple instances of the same report", {
@@ -180,12 +181,13 @@ test_that("workflow summary can handle multiple dependencies", {
     list(name = "depend4")
   )
   expect_equal(workflow_summary(path, reports),
-               list(reports = list(
-                 list(name = "depend4")
-               ),
-                    ref = NULL,
-                    missing_dependencies = list(
-                      depend4 = list("example", "depend2"))
+               list(
+                 reports = list(
+                   list(name = "depend4")
+                 ),
+                 ref = NULL,
+                 missing_dependencies = list(
+                   depend4 = list("example", "depend2"))
                ))
 
   reports <- list(
@@ -193,15 +195,16 @@ test_that("workflow summary can handle multiple dependencies", {
     list(name = "depend2")
   )
   expect_equal(workflow_summary(path, reports),
-               list(reports = list(
-                 list(name = "depend2"),
-                 list(name = "depend4",
-                      depends_on = "depend2")
-               ),
-                    ref = NULL,
-                    missing_dependencies = list(
-                      depend4 = list("example"),
-                      depend2 = list("example"))
+               list(
+                 reports = list(
+                   list(name = "depend2"),
+                   list(name = "depend4",
+                        depends_on = "depend2")
+                 ),
+                 ref = NULL,
+                 missing_dependencies = list(
+                   depend4 = list("example"),
+                   depend2 = list("example"))
                ))
 
   reports <- list(
@@ -210,18 +213,19 @@ test_that("workflow summary can handle multiple dependencies", {
     list(name = "example")
   )
   expect_equal(workflow_summary(path, reports),
-               list(reports = list(
-                 list(name = "example"),
-                 list(name = "depend2",
-                      depends_on = "example"),
-                 list(name = "depend4",
-                      depends_on = c("depend2", "example"))
-               ),
-                    ref = NULL,
-                    missing_dependencies = list(
-                      depend4 = list(),
-                      depend2 = list(),
-                      example = list())
+               list(
+                 reports = list(
+                   list(name = "example"),
+                   list(name = "depend2",
+                        depends_on = "example"),
+                   list(name = "depend4",
+                        depends_on = c("depend2", "example"))
+                 ),
+                 ref = NULL,
+                 missing_dependencies = list(
+                   depend4 = list(),
+                   depend2 = list(),
+                   example = list())
                ))
 
 
@@ -229,13 +233,14 @@ test_that("workflow summary can handle multiple dependencies", {
     list(name = "depend2")
   )
   expect_equal(workflow_summary(path, reports),
-               list(reports = list(
-                 list(name = "depend2")
-               ),
-                    ref = NULL,
-                    missing_dependencies = list(
-                      depend2 = list("example")
-                    )))
+               list(
+                 reports = list(
+                   list(name = "depend2")
+                 ),
+                 ref = NULL,
+                 missing_dependencies = list(
+                   depend2 = list("example")
+                 )))
 })
 
 test_that("workflow summary returns ref, instance and parameters", {
@@ -248,17 +253,18 @@ test_that("workflow summary returns ref, instance and parameters", {
          params = list(nmin = 0.5, another_param = "test"))
   )
   expect_equal(workflow_summary(path, reports, commits$id),
-               list(reports = list(
-                 list(name = "depend4",
-                      instance = "production",
-                      params = list(
-                        nmin = 0.5,
-                        another_param = "test"
-                      ))
-               ),
-                    ref = commits$id,
-                    missing_dependencies = list(
-                      depend4 = list("example", "depend2"))
+               list(
+                 reports = list(
+                   list(name = "depend4",
+                        instance = "production",
+                        params = list(
+                          nmin = 0.5,
+                          another_param = "test"
+                        ))
+                 ),
+                 ref = commits$id,
+                 missing_dependencies = list(
+                   depend4 = list("example", "depend2"))
                ))
 })
 


### PR DESCRIPTION
When requesting a workflow summary for reports that have no dependencies between them but mutliple instances of the same report, the order was being (seemingly arbitrarily) changed. 
E.g.
Input: other, global, other, connection
Output: other, global, connection, other

This commit fixes the actual bug: https://github.com/vimc/orderly.server/pull/90/commits/636ce4e063f2bfd86c6217e9f2949c8817dbdfea

But I still felt like the order reports were returned in was a little confusing at times. In particular if you input reports
a, b, c, d where c depends on b, I would naturally expect them to be returned a, c, b, d, but the returned order was a, d, c, b. Of course the latter is valid but it is more different to the original order. So [this commit](https://github.com/vimc/orderly.server/pull/90/commits/08a84e99656b124751c8e5bec3fd7c042bdd66c4) implements a different topological sorting algorithm which I think always produces an order closer to the original. See what you think; it's not as elegant as the original algorithm and maybe there are other cases I'm overlooking where the original produces a more "intuitive" order? Also haven't implemented the detection of cyclic dependencies, so would either need to add that in or use the old algorithm to do that.