### PR TITLE
Add report version artefact endpoint

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly.server
 Title: Serve Orderly
-Version: 0.3.22
+Version: 0.3.23
 Description: Run orderly reports as a server.
 License: MIT + file LICENSE
 Author: Rich FitzJohn

--- a/inst/schema/ReportVersionArtefact.schema.json
+++ b/inst/schema/ReportVersionArtefact.schema.json
@@ -1,0 +1,38 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "ReportVersionArtefact",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "id": {
+                "type": "integer"
+            },
+            "format": {
+                "enum": ["staticgraph", "interactivegraph", "data", "report",
+                         "interactivehtml"]
+            },
+            "description": {
+                "type": "string"
+            },
+            "files": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "filename": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "number"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": ["filename", "size"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["id", "format", "description", "files"]
+    }
+}

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -1,5 +1,16 @@
 # orderly.server API
 
+<!--
+
+To update the spec, the easiest thing to do is to:
+
+    ./scripts/redis start
+    ./scripts/demo
+
+which will start a server on 8080 with a bunch of reports in it already. A table of committed reports will be printed.
+
+-->
+
 This API is built on top of [`porcelain`](https://reside-ic.github.io/porcelain) (itself influenced by [`hintr`](https://github.com/mrc-ide/hintr) and [montagu api](https://github.com/vimc/montagu-api/blob/master/spec/spec.md)).
 
 

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -615,3 +615,75 @@ Response schema: [`WorkflowStatus.schema.json`](WorkflowStatus.schema.json)
 }
 ```
 
+## GET /report/version/:id/artefacts
+
+Get information about artefacts for a report.
+
+Note that the report name is not needed here.
+
+## Example
+
+```json
+{
+  "status": "success",
+  "errors": null,
+  "data": [
+    {
+      "id": 1,
+      "format": "data",
+      "description": "raw export",
+      "files": [
+        {
+          "filename": "all.csv",
+          "size": 801
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "format": "data",
+      "description": "the subset we care most about",
+      "files": [
+        {
+          "filename": "subset.csv",
+          "size": 127
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "format": "staticgraph",
+      "description": "plot of all data",
+      "files": [
+        {
+          "filename": "all.png",
+          "size": 9866
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "format": "staticgraph",
+      "description": "plot of a subset of the data",
+      "files": [
+        {
+          "filename": "subset.png",
+          "size": 4291
+        }
+      ]
+    }
+  ]
+}
+```
+
+If a nonexistant key is given the response is
+
+```json
+{
+  "status": "success",
+  "errors": null,
+  "data": []
+}
+```
+
+Schema: [`ReportVersionArtefact.schema.json`](ReportVersionArtefact.schema.json)

--- a/scripts/demo
+++ b/scripts/demo
@@ -1,0 +1,6 @@
+#!/usr/bin/env Rscript
+pkgload::load_all(export_all = FALSE, attach_testthat = FALSE)
+path <- orderly::orderly_example("demo", run_demo = TRUE, git = TRUE,
+                                 quiet = TRUE)
+print(orderly::orderly_list_archive(path))
+orderly.server::server(path, 8080, "127.0.0.1")

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -1044,3 +1044,26 @@ test_that("endpoint_report_info returns parameter info", {
   expect_null(info$data$logfile)
   expect_null(info$data$error)
 })
+
+
+test_that("can retrieve information about artefacts", {
+  path <- orderly_prepare_orderly_example("demo")
+  id <- orderly::orderly_run("other", parameters = list(nmin = 0.1),
+                             root = path, echo = FALSE)
+  orderly::orderly_commit(id, root = path)
+
+  data <- target_report_version_artefact(path, id)
+
+  endpoint <- endpoint_report_version_artefact(path)
+  res <- endpoint$run(id = id)
+
+  expect_true(res$validated)
+  expect_equal(res$status_code, 200)
+  expect_type(res$data, "list")
+  ## No need to check the format of the data all over as that's
+  ## duplicated by the schema check.  But here, check the first file
+  ## is indeed first:
+  expect_equal(res$data[[1]]$id, scalar(1L))
+  expect_equal(res$data[[1]]$description, scalar("A summary table"))
+  expect_equal(res$data[[1]]$files[[1]]$filename, scalar("summary.csv"))
+})


### PR DESCRIPTION
As described in https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-2961

Note that I've used `/report/version/:id/artefacts` not `/**reports**/version/:id/artefacts` as this only applies to a single report and because most of the stuff under `/reports` concerns itself with running.  Once we get this all in we might do a big tidyup of the API.