### PR TITLE
vimc-4929: Ensure workflow execution isolates failure

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -87,9 +87,6 @@ jobs:
           remotes::install_github("reside-ic/porcelain@22eef9b")
         shell: Rscript {0}
 
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
-
       - name: Check
         env:
           _R_CHECK_CRAN_INCOMING_REMOTE_: false

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -87,6 +87,9 @@ jobs:
           remotes::install_github("reside-ic/porcelain@22eef9b")
         shell: Rscript {0}
 
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
+
       - name: Check
         env:
           _R_CHECK_CRAN_INCOMING_REMOTE_: false

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Imports:
     porcelain (>= 0.1.4),
     processx,
     redux,
-    rrq (>= 0.5.0),
+    rrq (>= 0.5.6),
     utils,
     webutils,
     yaml,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,9 +19,7 @@ Imports:
     redux,
     rrq (>= 0.5.6),
     utils,
-    webutils,
-    yaml,
-    zip
+    yaml
 Suggests:
     callr,
     gert,
@@ -30,7 +28,8 @@ Suggests:
     mockery,
     RSQLite,
     testthat,
-    withr
+    withr,
+    zip
 RoxygenNote: 7.1.1
 Encoding: UTF-8
 Remotes:

--- a/R/runner.R
+++ b/R/runner.R
@@ -76,7 +76,6 @@ runner_run <- function(key_report_id, key, root, name, parameters, instance,
     id
   }
   id <- NA_character_
-  ## Might be worth killing px on function exit
   ## Pull out ID and save in redis as soon as possible with a busy wait
   ## then block wait for processx to finish
   while (px$is_alive()) {

--- a/R/workflows.R
+++ b/R/workflows.R
@@ -125,7 +125,8 @@ topological_sort <- function(graph) {
   stack <- 1
 
   while (any(!explored)) {
-    if (length(stack) > 1 && head(stack, n = 1) == tail(stack, n = 1)) {
+    if (length(stack) > 1 &&
+        utils::head(stack, n = 1) == utils::tail(stack, n = 1)) {
       stack <- rev(stack)
       node <- stack[1]
       nodes <- node

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -473,7 +473,7 @@ Response
 
 ## POST /workflow/run
 
-Run a set of reports as a workflow. Takes a set of reports to run, and any instance, params or dependencies between the reports. Works out the order the reports can be sent to the queue respecting any dependencies and adds them to the queue. Returns the ID of the workflow and each individual report.
+Run a set of reports as a workflow. Takes a set of reports to run, and any instance, params or dependencies between the reports. Works out the order the reports can be sent to the queue respecting any dependencies and adds them to the queue. Returns the ID of the workflow and each individual report. If 1 report fails reports dependent on the failed report will have status set to "impossible". Any independent reports will still be run.
 
 Request schema: [`WorkflowRunRequest.schema.json`](WorkflowRunRequest.schema.json)
 

--- a/tests/testthat/test-runner.R
+++ b/tests/testthat/test-runner.R
@@ -604,7 +604,8 @@ test_that("runner run passes git args to orderly CLI", {
   skip_if_no_redis()
   mock_processx <- mockery::mock(list(
     is_alive = function() FALSE,
-    get_exit_status = function() 0L), cycle = TRUE)
+    get_exit_status = function() 0L,
+    wait = function() TRUE), cycle = TRUE)
   mockery::stub(runner_run, "processx::process$new", mock_processx)
   run <- runner_run("key_report_id", "key", ".", "test", NULL, NULL,
                     ref = NULL, changelog = NULL)
@@ -637,7 +638,8 @@ test_that("runner run passes changelog to orderly CLI", {
   skip_if_no_redis()
   mock_processx <- mockery::mock(list(
     is_alive = function() FALSE,
-    get_exit_status = function() 0L), cycle = TRUE)
+    get_exit_status = function() 0L,
+    wait = function() TRUE), cycle = TRUE)
   mockery::stub(runner_run, "processx::process$new", mock_processx)
   run <- runner_run("key_report_id", "key", ".", "test", NULL, NULL,
                     ref = NULL, changelog = "[tst] message")

--- a/tests/testthat/test-workflows.R
+++ b/tests/testthat/test-workflows.R
@@ -759,7 +759,7 @@ test_that("workflow can be run: dependencies are cancelled on error", {
   ## We have in this setup
   ##        example
   ##        /  |   \
-  ##  depend   |    depend2
+  ##  depend   |    depend2 (this errors)
   ##           |   /
   ##        depend4
   ## so if depend2 errors we should see depend4 cancel
@@ -804,10 +804,7 @@ test_that("workflow can be run: dependencies are cancelled on error", {
 
   result_2 <- runner$queue$task_wait(task_ids[[2]])
   status_2 <- runner$status(res$reports[[2]], output = TRUE)
-  expect_equal(status_2$status, "success")
-  expect_match(status_2$version, "^\\d{8}-\\d{6}-\\w{8}")
-  expect_match(status_2$output, "\\[ name +\\]  depend4",
-               all = FALSE)
+  expect_equal(status_2$status, "impossible")
 
   result_3 <- runner$queue$task_wait(task_ids[[3]])
   status_3 <- runner$status(res$reports[[3]], output = TRUE)

--- a/tests/testthat/test-workflows.R
+++ b/tests/testthat/test-workflows.R
@@ -748,3 +748,78 @@ test_that("orderly workflow works with running a report twice", {
     depend4 = list("example", "depend2")
   ))
 })
+
+test_that("workflow can be run: dependencies are cancelled on error", {
+  testthat::skip_on_cran()
+  skip_on_windows()
+  skip_if_no_redis()
+  path <- orderly_git_example("depends", testing = TRUE)
+  runner <- orderly_runner(path)
+
+  ## We have in this setup
+  ##        example
+  ##        /  |   \
+  ##  depend   |    depend2
+  ##           |   /
+  ##        depend4
+  ## so if depend2 errors we should see depend4 cancel
+  ## but depend still run
+  err <- "stop('this report fails!')"
+  writeLines(err, file.path(path, "src/depend2/script.R"))
+  multiple_deps <- list(
+    list(
+      name = "example"
+    ),
+    list(
+      name = "depend4"
+    ),
+    list(
+      name = "depend2"
+    ),
+    list(
+      name = "depend"
+    )
+  )
+  res <- runner$submit_workflow(multiple_deps)
+  testthat::try_again(5, {
+    Sys.sleep(0.5)
+    tasks <- runner$queue$task_list()
+    expect_length(tasks, 4)
+  })
+  expect_equal(names(res), c("workflow_key", "reports"))
+  expect_true(!is.null(res$workflow_key))
+  redis_key <- workflow_redis_key(runner$queue$queue_id, res$workflow_key)
+  expect_setequal(runner$con$SMEMBERS(redis_key), res$reports)
+  expect_length(res$reports, 4)
+  task_ids <- vcapply(res$reports, function(id) get_task_id_key(runner, id))
+  expect_setequal(tasks, task_ids)
+
+  ## Order of returned tasks is correct
+  result_1 <- runner$queue$task_wait(task_ids[[1]])
+  status_1 <- runner$status(res$reports[[1]], output = TRUE)
+  expect_equal(status_1$status, "success")
+  expect_match(status_1$version, "^\\d{8}-\\d{6}-\\w{8}")
+  expect_match(status_1$output, "\\[ name +\\]  example",
+               all = FALSE)
+
+  result_2 <- runner$queue$task_wait(task_ids[[2]])
+  status_2 <- runner$status(res$reports[[2]], output = TRUE)
+  expect_equal(status_2$status, "success")
+  expect_match(status_2$version, "^\\d{8}-\\d{6}-\\w{8}")
+  expect_match(status_2$output, "\\[ name +\\]  depend4",
+               all = FALSE)
+
+  result_3 <- runner$queue$task_wait(task_ids[[3]])
+  status_3 <- runner$status(res$reports[[3]], output = TRUE)
+  expect_equal(status_3$status, "error")
+  expect_match(status_3$version, "^\\d{8}-\\d{6}-\\w{8}")
+  expect_match(status_3$output, "\\[ name +\\]  depend2",
+               all = FALSE)
+
+  result_4 <- runner$queue$task_wait(task_ids[[4]])
+  status_4 <- runner$status(res$reports[[4]], output = TRUE)
+  expect_equal(status_4$status, "success")
+  expect_match(status_4$version, "^\\d{8}-\\d{6}-\\w{8}")
+  expect_match(status_4$output, "\\[ name +\\]  depend",
+               all = FALSE)
+})


### PR DESCRIPTION
- [x] spec.md has been updated or doesn't need to updated

This PR will
* Add a test to confirm that if we run a workflow which contains some independent and some dependent reports if 1 report errors it only cancels run of dependent reports and not independent reports

This will fail until we merge https://github.com/mrc-ide/rrq/pull/62