### PR TITLE
mrc-3033 return execution order with running keys

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Suggests:
     testthat,
     withr,
     zip
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Encoding: UTF-8
 Remotes:
     reside-ic/porcelain,

--- a/R/api.R
+++ b/R/api.R
@@ -400,10 +400,7 @@ target_workflow_run <- function(runner, body) {
   body <- jsonlite::fromJSON(body, simplifyDataFrame = FALSE)
   changelog <- format_changelog(body$changelog)
   res <- runner$submit_workflow(body$reports, body$ref, changelog)
-  list(
-    workflow_key = scalar(res$workflow_key),
-    reports = res$reports
-  )
+  serialize_workflow_run(res)
 }
 
 endpoint_workflow_run <- function(runner) {

--- a/R/runner.R
+++ b/R/runner.R
@@ -314,13 +314,14 @@ orderly_runner_ <- R6::R6Class(
       redis_key <- workflow_redis_key(self$queue$queue_id, workflow_key)
       self$con$SADD(self$keys$key_workflows, workflow_key)
       self$con$SADD(redis_key, report_keys)
+      reports <- data.frame(key = report_keys, execution_order = seq_along(report_keys))
       ## Return in same order we received the reports
       ## These will be used by OW to map returned ID to specific report
       return_order <- vnapply(workflow, "[[", "original_order")
-      report_keys <- report_keys[order(return_order)]
+      reports <- reports[order(return_order), ]
       list(
         workflow_key = workflow_key,
-        reports = report_keys
+        reports = reports
       )
     },
 

--- a/R/runner.R
+++ b/R/runner.R
@@ -314,7 +314,8 @@ orderly_runner_ <- R6::R6Class(
       redis_key <- workflow_redis_key(self$queue$queue_id, workflow_key)
       self$con$SADD(self$keys$key_workflows, workflow_key)
       self$con$SADD(redis_key, report_keys)
-      reports <- data.frame(key = report_keys, execution_order = seq_along(report_keys))
+      reports <- data.frame(key = report_keys,
+                            execution_order = seq_along(report_keys))
       ## Return in same order we received the reports
       ## These will be used by OW to map returned ID to specific report
       return_order <- vnapply(workflow, "[[", "original_order")

--- a/R/workflows.R
+++ b/R/workflows.R
@@ -204,3 +204,26 @@ serialize_workflow_summary <- function(workflow) {
     missing_dependencies = recursive_scalar(workflow$missing_dependencies)
   )
 }
+
+## Has format matching WorkflowRunResponse schema
+## but we need to be careful with tagging items as scalar so it
+## serializes properly
+serialize_workflow_run <- function(workflow) {
+
+  serialize_report <- function(single_report) {
+    item <- list(
+      name = scalar(single_report$name)
+    )
+    item$instance <- scalar(single_report$instance)
+    item$params <- recursive_scalar(single_report$params)
+    item$depends_on <- single_report$depends_on
+    item$key <- scalar(single_report$key)
+    item$execution_order <- scalar(single_report$execution_order)
+    item
+  }
+
+  list(
+    workflow_key = scalar(workflow$workflow_key),
+    reports = lapply(workflow$reports, serialize_report)
+  )
+}

--- a/R/workflows.R
+++ b/R/workflows.R
@@ -183,21 +183,22 @@ workflow_combine_status <- function(report_status) {
   workflow_status
 }
 
+serialize_report <- function(single_report) {
+  item <- list(
+    name = scalar(single_report$name)
+  )
+  item$instance <- scalar(single_report$instance)
+  item$params <- recursive_scalar(single_report$params)
+  item$depends_on <- single_report$depends_on
+  item$key <- scalar(single_report$key)
+  item$execution_order <- scalar(single_report$execution_order)
+  item
+}
+
 ## Has format matching WorkflowSummaryResponse schema
 ## but we need to be careful with tagging items as scalar so it
 ## serializes properly
 serialize_workflow_summary <- function(workflow) {
-
-  serialize_report <- function(single_report) {
-    item <- list(
-      name = scalar(single_report$name)
-    )
-    item$instance <- scalar(single_report$instance)
-    item$params <- recursive_scalar(single_report$params)
-    item$depends_on <- single_report$depends_on
-    item
-  }
-
   list(
     reports = lapply(workflow$reports, serialize_report),
     ref = scalar(workflow$ref),
@@ -209,19 +210,6 @@ serialize_workflow_summary <- function(workflow) {
 ## but we need to be careful with tagging items as scalar so it
 ## serializes properly
 serialize_workflow_run <- function(workflow) {
-
-  serialize_report <- function(single_report) {
-    item <- list(
-      name = scalar(single_report$name)
-    )
-    item$instance <- scalar(single_report$instance)
-    item$params <- recursive_scalar(single_report$params)
-    item$depends_on <- single_report$depends_on
-    item$key <- scalar(single_report$key)
-    item$execution_order <- scalar(single_report$execution_order)
-    item
-  }
-
   list(
     workflow_key = scalar(workflow$workflow_key),
     reports = lapply(workflow$reports, serialize_report)

--- a/inst/schema/WorkflowRunResponse.schema.json
+++ b/inst/schema/WorkflowRunResponse.schema.json
@@ -2,11 +2,29 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "WorkflowRunResponse",
     "type": "object",
+    "definitions": {
+        "queuedReport": {
+            "type": "object",
+            "properties": {
+                "key": {
+                    "type": "string"
+                },
+                "execution_order": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "key",
+                "execution_order"
+            ],
+            "additionalProperties": false
+        }
+    },
     "properties": {
         "workflow_key": { "type": "string" },
         "reports": {
             "type": "array",
-            "items": { "type": "string" }
+            "items": { "$ref": "#/definitions/queuedReport" }
         }
     },
     "required": ["workflow_key", "reports"],

--- a/inst/schema/WorkflowRunResponse.schema.json
+++ b/inst/schema/WorkflowRunResponse.schema.json
@@ -6,14 +6,18 @@
         "queuedReport": {
             "type": "object",
             "properties": {
-                "key": {
-                    "type": "string"
+                "name": { "type": "string" },
+                "instance": { "type": "string" },
+                "params": { "$ref": "Parameters.schema.json" },
+                "depends_on": {
+                    "type": "array",
+                    "items": { "type": "string" }
                 },
-                "execution_order": {
-                    "type": "number"
-                }
+                "key": {  "type": "string" },
+                "execution_order": { "type": "number" }
             },
             "required": [
+                "name",
                 "key",
                 "execution_order"
             ],

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -526,7 +526,7 @@ Response
       {
         "name": "other",
         "params": {
-          "nmin": [0.5]
+          "nmin": 0.5
         },
         "key": "deific_thrip",
         "execution_order": 1

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -515,13 +515,23 @@ Request
 ```
 
 Response
+
 ```json
 {
   "status": "success",
   "errors": null,
   "data": {
     "workflow_key": "aghast_wolf",
-    "reports": ["deific_thrip", "monarchistic_blackmamba"]
+    "reports": [
+      {
+        "key": "deific_thrip",
+        "execution_order": 1
+      },
+      {
+        "key": "monarchistic_blackmamba",
+        "execution_order": 2
+      }
+    ]
   }
 }
 ```

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -524,10 +524,15 @@ Response
     "workflow_key": "aghast_wolf",
     "reports": [
       {
+        "name": "other",
+        "params": {
+          "nmin": [0.5]
+        },
         "key": "deific_thrip",
         "execution_order": 1
       },
       {
+        "name": "minimal",
         "key": "monarchistic_blackmamba",
         "execution_order": 2
       }

--- a/tests/testthat/test-workflows.R
+++ b/tests/testthat/test-workflows.R
@@ -465,13 +465,14 @@ test_that("workflow can be run: simple", {
   expect_equal(names(res), c("workflow_key", "reports"))
   expect_true(!is.null(res$workflow_key))
   redis_key <- workflow_redis_key(runner$queue$queue_id, res$workflow_key)
-  expect_equal(runner$con$SMEMBERS(redis_key), list(res$reports$key))
-  expect_equal(nrow(res$reports), 1)
-  task_id <- get_task_id_key(runner, res$reports$key)
+  report_keys <- vcapply(res$reports, "[[", "key")
+  expect_equal(runner$con$SMEMBERS(redis_key), list(report_keys))
+  expect_length(res$reports, 1)
+  task_id <- get_task_id_key(runner, report_keys)
   expect_equal(tasks, task_id)
 
   result <- runner$queue$task_wait(task_id)
-  status <- runner$status(res$reports$key, output = TRUE)
+  status <- runner$status(report_keys, output = TRUE)
   expect_equal(status$status, "success")
   expect_match(status$version, "^\\d{8}-\\d{6}-\\w{8}")
   expect_type(status$start_time, "double")
@@ -506,14 +507,15 @@ test_that("workflow can be run: dependencies", {
   expect_equal(names(res), c("workflow_key", "reports"))
   expect_true(!is.null(res$workflow_key))
   redis_key <- workflow_redis_key(runner$queue$queue_id, res$workflow_key)
-  expect_setequal(runner$con$SMEMBERS(redis_key), res$reports$key)
-  expect_equal(nrow(res$reports), 3)
-  task_ids <- vcapply(res$reports$key, function(id) get_task_id_key(runner, id))
+  report_keys <- vcapply(res$reports, "[[", "key")
+  expect_setequal(runner$con$SMEMBERS(redis_key), report_keys)
+  expect_length(res$reports, 3)
+  task_ids <- vcapply(report_keys, function(id) get_task_id_key(runner, id))
   expect_setequal(tasks, task_ids)
 
   ## Order of returned tasks is correct
   result_1 <- runner$queue$task_wait(task_ids[[1]])
-  status_1 <- runner$status(res$reports$key[[1]], output = TRUE)
+  status_1 <- runner$status(report_keys[[1]], output = TRUE)
   expect_equal(status_1$status, "success")
   expect_match(status_1$version, "^\\d{8}-\\d{6}-\\w{8}")
   expect_type(status_1$start_time, "double")
@@ -521,7 +523,7 @@ test_that("workflow can be run: dependencies", {
                all = FALSE)
 
   result_2 <- runner$queue$task_wait(task_ids[[2]])
-  status_2 <- runner$status(res$reports$key[[2]], output = TRUE)
+  status_2 <- runner$status(report_keys[[2]], output = TRUE)
   expect_equal(status_2$status, "success")
   expect_match(status_2$version, "^\\d{8}-\\d{6}-\\w{8}")
   expect_type(status_2$start_time, "double")
@@ -529,7 +531,7 @@ test_that("workflow can be run: dependencies", {
                all = FALSE)
 
   result_3 <- runner$queue$task_wait(task_ids[[3]])
-  status_3 <- runner$status(res$reports$key[[3]], output = TRUE)
+  status_3 <- runner$status(report_keys[[3]], output = TRUE)
   expect_equal(status_3$status, "success")
   expect_match(status_3$version, "^\\d{8}-\\d{6}-\\w{8}")
   expect_type(status_3$start_time, "double")
@@ -537,7 +539,8 @@ test_that("workflow can be run: dependencies", {
                all = FALSE)
 
   # execution order also returned
-  expect_equal(res$reports$execution_order, c(1, 3, 2))
+  order <- vcapply(report_keys, "[[", "execution_order")
+  expect_equal(order, c(1, 3, 2))
 
   ## depend2 run used artefacts from example run
   expect_match(status_3$output,
@@ -695,8 +698,9 @@ test_that("can get status of a worfklow", {
   expect_equal(status$workflow_key, res$workflow_key)
   expect_equal(status$status, "success")
   expect_length(status$reports, 3)
-  report_keys <- lapply(status$reports, "[[", "key")
-  expect_setequal(report_keys, res$reports$key)
+  status_keys <- lapply(status$reports, "[[", "key")
+  report_keys <- lapply(res$reports, "[[", "key")
+  expect_setequal(report_keys, status_keys)
   expect_equal(status$reports[[1]]$status, "success")
   expect_match(status$reports[[1]]$version, "^\\d{8}-\\d{6}-\\w{8}")
   expect_type(status$reports[[1]]$start_time, "double")
@@ -799,32 +803,33 @@ test_that("workflow can be run: dependencies are cancelled on error", {
   expect_equal(names(res), c("workflow_key", "reports"))
   expect_true(!is.null(res$workflow_key))
   redis_key <- workflow_redis_key(runner$queue$queue_id, res$workflow_key)
-  expect_setequal(runner$con$SMEMBERS(redis_key), res$reports$key)
-  expect_equal(nrow(res$reports), 4)
-  task_ids <- vcapply(res$reports$key, function(id) get_task_id_key(runner, id))
+  report_keys <- vcapply(res$reports, "[[", "key")
+  expect_setequal(runner$con$SMEMBERS(redis_key), report_keys)
+  expect_length(res$reports, 4)
+  task_ids <- vcapply(report_keys, function(id) get_task_id_key(runner, id))
   expect_setequal(tasks, task_ids)
 
   ## Order of returned tasks is correct
   result_1 <- runner$queue$task_wait(task_ids[[1]])
-  status_1 <- runner$status(res$reports$key[[1]], output = TRUE)
+  status_1 <- runner$status(report_keys[[1]], output = TRUE)
   expect_equal(status_1$status, "success")
   expect_match(status_1$version, "^\\d{8}-\\d{6}-\\w{8}")
   expect_match(status_1$output, "\\[ name +\\]  example",
                all = FALSE)
 
   result_2 <- runner$queue$task_wait(task_ids[[2]])
-  status_2 <- runner$status(res$reports$key[[2]], output = TRUE)
+  status_2 <- runner$status(report_keys[[2]], output = TRUE)
   expect_equal(status_2$status, "impossible")
 
   result_3 <- runner$queue$task_wait(task_ids[[3]])
-  status_3 <- runner$status(res$reports$key[[3]], output = TRUE)
+  status_3 <- runner$status(report_keys[[3]], output = TRUE)
   expect_equal(status_3$status, "error")
   expect_match(status_3$version, "^\\d{8}-\\d{6}-\\w{8}")
   expect_match(status_3$output, "\\[ name +\\]  depend2",
                all = FALSE)
 
   result_4 <- runner$queue$task_wait(task_ids[[4]])
-  status_4 <- runner$status(res$reports$key[[4]], output = TRUE)
+  status_4 <- runner$status(report_keys[[4]], output = TRUE)
   expect_equal(status_4$status, "success")
   expect_match(status_4$version, "^\\d{8}-\\d{6}-\\w{8}")
   expect_match(status_4$output, "\\[ name +\\]  depend",

--- a/tests/testthat/test-workflows.R
+++ b/tests/testthat/test-workflows.R
@@ -527,7 +527,7 @@ test_that("workflow can be run: dependencies", {
   expect_equal(status_2$status, "success")
   expect_match(status_2$version, "^\\d{8}-\\d{6}-\\w{8}")
   expect_type(status_2$start_time, "double")
-  expect_match(status_2$output, "\\[ name +\\]  depend4",
+  expect_match(status_2$output, "\\[ name +\\]  depend2",
                all = FALSE)
 
   result_3 <- runner$queue$task_wait(task_ids[[3]])
@@ -535,24 +535,24 @@ test_that("workflow can be run: dependencies", {
   expect_equal(status_3$status, "success")
   expect_match(status_3$version, "^\\d{8}-\\d{6}-\\w{8}")
   expect_type(status_3$start_time, "double")
-  expect_match(status_3$output, "\\[ name +\\]  depend2",
+  expect_match(status_3$output, "\\[ name +\\]  depend4",
                all = FALSE)
 
   # execution order also returned
-  order <- vcapply(report_keys, "[[", "execution_order")
-  expect_equal(order, c(1, 3, 2))
+  order <- vnapply(res$reports, "[[", "execution_order")
+  expect_equal(order, c(1, 2, 3))
 
   ## depend2 run used artefacts from example run
-  expect_match(status_3$output,
+  expect_match(status_2$output,
                paste0("\\[ depends +\\]  example@", status_1$version),
                all = FALSE)
 
   ## depend4 run using artefacts from example & depend2 runs
-  expect_match(status_2$output,
+  expect_match(status_3$output,
                paste0("\\[ depends +\\]  example@", status_1$version),
                all = FALSE)
-  expect_match(status_2$output,
-               paste0("\\[ ... +\\]  depend2@", status_3$version),
+  expect_match(status_3$output,
+               paste0("\\[ ... +\\]  depend2@", status_2$version),
                all = FALSE)
 })
 
@@ -819,14 +819,14 @@ test_that("workflow can be run: dependencies are cancelled on error", {
 
   result_2 <- runner$queue$task_wait(task_ids[[2]])
   status_2 <- runner$status(report_keys[[2]], output = TRUE)
-  expect_equal(status_2$status, "impossible")
+  expect_equal(status_2$status, "error")
+  expect_match(status_2$version, "^\\d{8}-\\d{6}-\\w{8}")
+  expect_match(status_2$output, "\\[ name +\\]  depend2",
+               all = FALSE)
 
   result_3 <- runner$queue$task_wait(task_ids[[3]])
   status_3 <- runner$status(report_keys[[3]], output = TRUE)
-  expect_equal(status_3$status, "error")
-  expect_match(status_3$version, "^\\d{8}-\\d{6}-\\w{8}")
-  expect_match(status_3$output, "\\[ name +\\]  depend2",
-               all = FALSE)
+  expect_equal(status_3$status, "impossible")
 
   result_4 <- runner$queue$task_wait(task_ids[[4]])
   status_4 <- runner$status(report_keys[[4]], output = TRUE)
@@ -834,4 +834,6 @@ test_that("workflow can be run: dependencies are cancelled on error", {
   expect_match(status_4$version, "^\\d{8}-\\d{6}-\\w{8}")
   expect_match(status_4$output, "\\[ name +\\]  depend",
                all = FALSE)
+
+
 })

--- a/tests/testthat/test-z-integration.R
+++ b/tests/testthat/test-z-integration.R
@@ -607,11 +607,11 @@ test_that("workflow can be run", {
   expect_equal(names(dat$data), c("workflow_key", "reports"))
   expect_length(dat$data$reports, 2)
 
-  wait_for_finished(dat$data$reports[1], server)
-  wait_for_finished(dat$data$reports[2], server)
+  wait_for_finished(dat$data$reports[[1]]$key, server)
+  wait_for_finished(dat$data$reports[[2]]$key, server)
 
   report_1_status <- httr::GET(server$api_url(
-    sprintf("/v1/reports/%s/status/", dat$data$reports[1])),
+    sprintf("/v1/reports/%s/status/", dat$data$reports[[1]]$key)),
     query = list(output = TRUE))
   expect_equal(httr::status_code(report_1_status), 200)
   status_1 <- content(report_1_status)
@@ -620,7 +620,7 @@ test_that("workflow can be run", {
   expect_true(!is.null(status_1$data$version))
 
   report_2_status <- httr::GET(server$api_url(
-    sprintf("/v1/reports/%s/status/", dat$data$reports[2])),
+    sprintf("/v1/reports/%s/status/", dat$data$reports[[2]]$key)),
     query = list(output = TRUE))
   expect_equal(httr::status_code(report_2_status), 200)
   status_2 <- content(report_2_status)


### PR DESCRIPTION
- [x] spec.md has been updated or doesn't need to updated

Return execution order of reports on workflow submission, to be recorded by OW to ensure consistency when displaying running statuses against a workflow summary.