### PR TITLE
Add report version instances endpoint

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly.server
 Title: Serve Orderly
-Version: 0.3.24
+Version: 0.3.25
 Description: Run orderly reports as a server.
 License: MIT + file LICENSE
 Author: Rich FitzJohn

--- a/R/api.R
+++ b/R/api.R
@@ -488,3 +488,24 @@ endpoint_report_version_artefact <- function(path) {
     porcelain::porcelain_state(path = path),
     returning = returning_json("ReportVersionArtefact.schema"))
 }
+
+
+target_report_version_instances <- function(path, id) {
+  db <- orderly::orderly_db("destination", root = path)
+  sql <- paste(
+    "select report_version_instance.instance,",
+    "       report_version_instance.type",
+    "  from report_version_instance",
+    " where report_Version_instance.report_version = $1")
+  dat <- DBI::dbGetQuery(db, sql, id)
+  set_names(lapply(dat$instance, scalar), dat$type)
+}
+
+
+endpoint_report_version_instances <- function(path) {
+  porcelain::porcelain_endpoint$new(
+    "GET", "/v1/report/version/<id>/instances",
+    target_report_version_instances,
+    porcelain::porcelain_state(path = path),
+    returning = returning_json("ReportVersionInstances.schema"))
+}

--- a/R/util.R
+++ b/R/util.R
@@ -181,3 +181,7 @@ key_value_collector <- function(init = list()) {
        get_all = function() env$res,
        get = function(keys) unlist(lapply(keys, get), recursive = FALSE))
 }
+
+squote <- function(x) {
+  sprintf("'%s'", x)
+}

--- a/inst/schema/ReportVersionInstances.schema.json
+++ b/inst/schema/ReportVersionInstances.schema.json
@@ -3,6 +3,9 @@
     "id": "ReportVersionInstances",
     "type": "object",
     "additionalProperties": {
-        "type": "string"
+        "type": "object",
+        "additionalProperties": {
+            "type": "string"
+        }
     }
 }

--- a/inst/schema/ReportVersionInstances.schema.json
+++ b/inst/schema/ReportVersionInstances.schema.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "ReportVersionInstances",
+    "type": "object",
+    "additionalProperties": {
+        "type": "string"
+    }
+}

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -702,3 +702,23 @@ If a nonexistant key is given the response is
 ```
 
 Schema: [`ReportVersionArtefact.schema.json`](ReportVersionArtefact.schema.json)
+
+## GET /report/version/:id/instances
+
+Get information about instances used by a report
+
+Note that the report name is not needed here.
+
+## Example
+
+```json
+{
+  "status": "success",
+  "errors": null,
+  "data": {
+    "source": "alternative"
+  }
+}
+```
+
+Schema: [`ReportVersionInstances.schema.json`](ReportVersionInstances.schema.json)

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -703,20 +703,31 @@ If a nonexistant key is given the response is
 
 Schema: [`ReportVersionArtefact.schema.json`](ReportVersionArtefact.schema.json)
 
-## GET /report/version/:id/instances
+## GET /report/metadata/instances
 
-Get information about instances used by a report
+Get information about instances used by a report.  Accepts the query parameter `version` which is a comma-separated list of report ids.
 
 Note that the report name is not needed here.
 
 ## Example
+
+```
+GET /report/metadata/instances?version=20220408-094127-5bd0f4e,b20220408-094148-8f77a35a
+```
+
 
 ```json
 {
   "status": "success",
   "errors": null,
   "data": {
-    "source": "alternative"
+    {
+      "20220408-094127-5bd0f4eb": {
+        "source": "alternative"
+      },
+      "20220408-094148-8f77a35a": {
+        "source": "production"
+      }
   }
 }
 ```

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -728,6 +728,7 @@ GET /report/metadata/instances?version=20220408-094127-5bd0f4e,b20220408-094148-
       "20220408-094148-8f77a35a": {
         "source": "production"
       }
+    }
   }
 }
 ```

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -1102,18 +1102,29 @@ test_that("Can retrieve information about instances", {
     id
   }
 
-  id <- run_and_commit("example", instance = "alternative")
-  expected <- list(source = scalar("alternative"))
+  id1 <- run_and_commit("example", instance = "alternative")
+  id2 <- run_and_commit("example", instance = "default")
 
+  expected1 <- set_names(list(list(source = scalar("alternative"))),
+                         id1)
+  expected2 <- set_names(list(list(source = scalar("alternative")),
+                              list(source = scalar("default"))),
+                         c(id1, id2))
+
+  expect_equal(target_report_version_instances(path, id1), expected1)
+  expect_equal(target_report_version_instances(path, c(id1, id2)), expected2)
   expect_equal(
-    target_report_version_instances(path, id),
-    expected)
+    target_report_version_instances(path, paste(id1, id2, sep = ",")),
+    expected2)
 
   endpoint <- endpoint_report_version_instances(path)
-  res <- endpoint$run(id)
-  expect_equal(res$data, expected)
+  res1 <- endpoint$run(id1)
+  expect_equal(res1$data, expected1)
+  expect_true(res1$validated)
+  expect_equal(res1$status_code, 200)
 
-  expect_true(res$validated)
-  expect_equal(res$status_code, 200)
-  expect_type(res$data, "list")
+  res2 <- endpoint$run(paste(id1, id2, sep = ","))
+  expect_equal(res2$data, expected2)
+  expect_true(res2$validated)
+  expect_equal(res2$status_code, 200)
 })


### PR DESCRIPTION
- [x] spec.md has been updated or doesn't need to updated

Adds a database instance endpoint, as outlined in the corresponding ticket.

When we generalise things later, this might need some care as it's stuff that only some instances will use