### PR TITLE
vimc-6428: Add parameter, ref and instance info to queue status

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly.server
 Title: Serve Orderly
-Version: 0.3.24
+Version: 0.3.25
 Description: Run orderly reports as a server.
 License: MIT + file LICENSE
 Author: Rich FitzJohn

--- a/R/api.R
+++ b/R/api.R
@@ -422,9 +422,7 @@ target_workflow_status <- function(runner, workflow_key, output = FALSE) {
       version = scalar(report$version),
       start_time = scalar(report$start_time),
       output = report$output,
-      queue = lapply(report$queue, function(item) {
-        lapply(item, scalar)
-      })
+      queue = recursive_scalar(report$queue)
     )
   })
   list(

--- a/R/runner.R
+++ b/R/runner.R
@@ -528,8 +528,11 @@ orderly_runner_ <- R6::R6Class(
       list(
         key = key,
         status = status,
+        version = report_id,
         name = task_data$expr$name,
-        version = report_id
+        params = task_data$expr$parameters,
+        ref = task_data$expr$ref,
+        instance = task_data$expr$instance
       )
     }
   )

--- a/R/runner.R
+++ b/R/runner.R
@@ -529,10 +529,13 @@ orderly_runner_ <- R6::R6Class(
         key = key,
         status = status,
         version = report_id,
-        name = task_data$expr$name,
-        params = task_data$expr$parameters,
-        ref = task_data$expr$ref,
-        instance = task_data$expr$instance
+        inputs = list(
+          name = task_data$expr$name,
+          params = task_data$expr$parameters,
+          ref = task_data$expr$ref,
+          instance = task_data$expr$instance,
+          changelog = task_data$expr$changelog
+        )
       )
     }
   )

--- a/inst/schema/QueueStatus.schema.json
+++ b/inst/schema/QueueStatus.schema.json
@@ -15,17 +15,26 @@
                     "version": {
                         "type": [ "string", "null" ]
                     },
-                    "name": {"type": "string"},
-                    "params": { "$ref": "Parameters.schema.json" },
-                    "ref": {
-                        "type": [ "string", "null" ]
-                    },
-                    "instance": {
-                        "type": [ "string", "null" ]
+                    "inputs" :{
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "params": { "$ref": "Parameters.schema.json" },
+                            "ref": {
+                                "type": [ "string", "null" ]
+                            },
+                            "instance": {
+                                "type": [ "string", "null" ]
+                            },
+                            "changelog": {
+                                "type": [ "string", "null" ]
+                            }
+                        },
+                        "required": ["name", "params", "ref", "instance",
+                                     "changelog"]
                     }
                 },
-                "required": ["key", "status", "version", "name", "params",
-                             "ref", "instance"],
+                "required": ["key", "status", "version", "inputs"],
                 "additionalProperties": false
             }
         }

--- a/inst/schema/QueueStatus.schema.json
+++ b/inst/schema/QueueStatus.schema.json
@@ -12,12 +12,20 @@
                     "status": {
                         "$ref": "TaskStatus.schema.json"
                     },
-                    "name": {"type": "string"},
                     "version": {
+                        "type": [ "string", "null" ]
+                    },
+                    "name": {"type": "string"},
+                    "params": { "$ref": "Parameters.schema.json" },
+                    "ref": {
+                        "type": [ "string", "null" ]
+                    },
+                    "instance": {
                         "type": [ "string", "null" ]
                     }
                 },
-                "required": ["key", "status", "name", "version"],
+                "required": ["key", "status", "version", "name", "params",
+                             "ref", "instance"],
                 "additionalProperties": false
             }
         }

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -91,14 +91,20 @@ Schema: [`Status.schema.json`](Status.schema.json)
         {
             "key": "antiutopian_peregrinefalcon",
             "status": "running",
-            "name": "minimal",
             "version": "20210211-143212-98c45632"
+            "name": "minimal",
+            "params": null,
+            "ref": null,
+            "instance": null
         },
         {
             "key": "flavoured_bassethound",
             "status": "queued",
+            "version": null,
             "name": "other",
-            "version": null
+            "params": { "nmin": "0.5" },
+            "ref": null,
+            "instance": null
         }
     ]
 }
@@ -153,14 +159,20 @@ Schema: [`QueueStatus.schema.json`](QueueStatus.schema.json)
     {
         "key": "antiutopian_peregrinefalcon",
         "status": "running",
+        "version": "20210211-143212-98c45632",
         "name": "minimal",
-        "version": "20210211-143212-98c45632"
+        "params": null,
+        "ref": "3e0d1d2",
+        "instance": "production"
     },
     {
         "key": "flavoured_bassethound",
         "status": "queued",
+        "version": null,
         "name": "other",
-        "version": null
+        "params": { "nmin": "0.5" },
+        "ref": null,
+        "instance": null
     }
 ]
 ```

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -91,20 +91,26 @@ Schema: [`Status.schema.json`](Status.schema.json)
         {
             "key": "antiutopian_peregrinefalcon",
             "status": "running",
-            "version": "20210211-143212-98c45632"
-            "name": "minimal",
-            "params": null,
-            "ref": null,
-            "instance": null
+            "version": "20210211-143212-98c45632",
+            "inputs": {
+                "name": "minimal",
+                "params": null,
+                "ref": null,
+                "instance": null,
+                "changelog": null
+            }
         },
         {
             "key": "flavoured_bassethound",
             "status": "queued",
             "version": null,
-            "name": "other",
-            "params": { "nmin": "0.5" },
-            "ref": null,
-            "instance": null
+            "inputs": {
+                "name": "other",
+                "params": { "nmin": "0.5" },
+                "ref": null,
+                "instance": null,
+                "changelog": "[internal] changelog message"
+            }
         }
     ]
 }
@@ -160,19 +166,25 @@ Schema: [`QueueStatus.schema.json`](QueueStatus.schema.json)
         "key": "antiutopian_peregrinefalcon",
         "status": "running",
         "version": "20210211-143212-98c45632",
-        "name": "minimal",
-        "params": null,
-        "ref": "3e0d1d2",
-        "instance": "production"
+        "inputs": {
+            "name": "minimal",
+            "params": null,
+            "ref": "3e0d1d2",
+            "instance": "production",
+            "changelog": null
+        }
     },
     {
         "key": "flavoured_bassethound",
         "status": "queued",
         "version": null,
-        "name": "other",
-        "params": { "nmin": "0.5" },
-        "ref": null,
-        "instance": null
+        "inputs": {
+            "name": "other",
+            "params": { "nmin": "0.5" },
+            "ref": null,
+            "instance": null,
+            "changelog": "[internal] changelog message"
+        }
     }
 ]
 ```

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -455,19 +455,23 @@ test_that("queue status", {
         key = "key-1",
         status = "running",
         version = "20210310-123928-fef89bc7",
-        name = "minimal",
-        params = list(timeout = 10, poll = 1),
-        ref = NULL,
-        instance = NULL
+        inputs = list(
+          name = "minimal",
+          params = list(timeout = 10, poll = 1),
+          ref = NULL,
+          instance = NULL,
+          changelog = "[internal] changelog")
       ),
       list(
         key = "key-2",
         status = "queued",
         version = NULL,
-        name = "minimal",
-        params = NULL,
-        ref = "123",
-        instance = "production")
+        inputs = list(
+          name = "minimal",
+          params = NULL,
+          ref = "123",
+          instance = "production",
+          changelog = NULL))
     )
   )
 
@@ -481,19 +485,23 @@ test_that("queue status", {
         key = scalar("key-1"),
         status = scalar("running"),
         version = scalar("20210310-123928-fef89bc7"),
-        name = scalar("minimal"),
-        params = list(timeout = scalar(10), poll = scalar(1)),
-        ref = NULL,
-        instance = NULL
+        inputs = list(
+          name = scalar("minimal"),
+          params = list(timeout = scalar(10), poll = scalar(1)),
+          ref = NULL,
+          instance = NULL,
+          changelog = scalar("[internal] changelog"))
       ),
       list(
         key = scalar("key-2"),
         status = scalar("queued"),
         version = NULL,
-        name = scalar("minimal"),
-        params = NULL,
-        ref = scalar("123"),
-        instance = scalar("production")))))
+        inputs = list(
+          name = scalar("minimal"),
+          params = NULL,
+          ref = scalar("123"),
+          instance = scalar("production"),
+          changelog = NULL)))))
   mockery::expect_called(runner$queue_status, 1)
 
   ## endpoint

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -454,14 +454,20 @@ test_that("queue status", {
       list(
         key = "key-1",
         status = "running",
+        version = "20210310-123928-fef89bc7",
         name = "minimal",
-        version = "20210310-123928-fef89bc7"
+        params = list(timeout = 10, poll = 1),
+        ref = NULL,
+        instance = NULL
       ),
       list(
         key = "key-2",
         status = "queued",
+        version = NULL,
         name = "minimal",
-        version = NULL)
+        params = NULL,
+        ref = "123",
+        instance = "production")
     )
   )
 
@@ -474,14 +480,20 @@ test_that("queue status", {
       list(
         key = scalar("key-1"),
         status = scalar("running"),
+        version = scalar("20210310-123928-fef89bc7"),
         name = scalar("minimal"),
-        version = scalar("20210310-123928-fef89bc7")
+        params = list(timeout = scalar(10), poll = scalar(1)),
+        ref = NULL,
+        instance = NULL
       ),
       list(
         key = scalar("key-2"),
         status = scalar("queued"),
+        version = NULL,
         name = scalar("minimal"),
-        version = NULL))))
+        params = NULL,
+        ref = scalar("123"),
+        instance = scalar("production")))))
   mockery::expect_called(runner$queue_status, 1)
 
   ## endpoint

--- a/tests/testthat/test-api-workflows.R
+++ b/tests/testthat/test-api-workflows.R
@@ -406,8 +406,15 @@ test_that("workflow status - queued", {
                                 list(
                                   key = "key-1",
                                   status = "running",
-                                  name = "minimal",
-                                  version = "20210310-123928-fef89bc7"
+                                  version = "20210310-123928-fef89bc7",
+                                  inputs = list(
+                                    name = "minimal",
+                                    params = list(timeout = 10,
+                                                  poll = 1),
+                                    ref = NULL,
+                                    instance = NULL,
+                                    changelog = "[internal] changelog"
+                                  )
                                 )))))
 
   runner <- mock_runner(key, workflow_status = workflow_status)
@@ -428,12 +435,18 @@ test_that("workflow status - queued", {
                list(
                  key = scalar("key-1"),
                  status = scalar("running"),
-                 name = scalar("minimal"),
-                 version = scalar("20210310-123928-fef89bc7")
+                 version = scalar("20210310-123928-fef89bc7"),
+                 inputs = list(
+                   name = scalar("minimal"),
+                   params = list(timeout = scalar(10),
+                                 poll = scalar(1)),
+                   ref = NULL,
+                   instance = NULL,
+                   changelog = scalar("[internal] changelog")
                )
              )
            )
-         )))
+         ))))
   mockery::expect_called(runner$workflow_status, 1)
   expect_equal(mockery::mock_args(runner$workflow_status)[[1]],
                list(workflow_key, FALSE))

--- a/tests/testthat/test-runner.R
+++ b/tests/testthat/test-runner.R
@@ -664,7 +664,8 @@ test_that("status: lists queued tasks", {
 
   key1 <- runner$submit_task_report("interactive")
   key2 <- runner$submit_task_report("count_params",
-                                    parameters = list(timeout = 10, poll = 1))
+                                    parameters = list(timeout = 10, poll = 1),
+                                    changelog = "[internal] changelog")
   key3 <- runner$submit_task_report("interactive", instance = "production",
                                     ref = "123")
   key4 <- runner$submit_task_report("interactive")
@@ -686,10 +687,12 @@ test_that("status: lists queued tasks", {
       key = key1,
       status = "running",
       version = key1_status$version,
-      name = "interactive",
-      params = NULL,
-      ref = NULL,
-      instance = NULL
+      inputs = list(
+        name = "interactive",
+        params = NULL,
+        ref = NULL,
+        instance = NULL,
+        changelog = NULL)
     )
   ))
   key3_status <- runner$status(key3)
@@ -699,46 +702,56 @@ test_that("status: lists queued tasks", {
       key = key1,
       status = "running",
       version = key1_status$version,
-      name = "interactive",
-      params = NULL,
-      ref = NULL,
-      instance = NULL
+      inputs = list(
+        name = "interactive",
+        params = NULL,
+        ref = NULL,
+        instance = NULL,
+        changelog = NULL)
     ),
     list(
       key = key2,
       status = "queued",
       version = NULL,
-      name = "count_params",
-      params = list(timeout = 10, poll = 1),
-      ref = NULL,
-      instance = NULL)))
+      inputs = list(
+        name = "count_params",
+        params = list(timeout = 10, poll = 1),
+        ref = NULL,
+        instance = NULL,
+        changelog = "[internal] changelog"))))
   expect_equal(key4_status$queue, list(
     list(
       key = key1,
       status = "running",
       version = key1_status$version,
-      name = "interactive",
-      params = NULL,
-      ref = NULL,
-      instance = NULL
+      inputs = list(
+        name = "interactive",
+        params = NULL,
+        ref = NULL,
+        instance = NULL,
+        changelog = NULL)
     ),
     list(
       key = key2,
       status = "queued",
       version = NULL,
-      name = "count_params",
-      params = list(timeout = 10, poll = 1),
-      ref = NULL,
-      instance = NULL
+      inputs = list(
+        name = "count_params",
+        params = list(timeout = 10, poll = 1),
+        ref = NULL,
+        instance = NULL,
+        changelog = "[internal] changelog")
     ),
     list(
       key = key3,
       status = "queued",
       version = NULL,
+      inputs = list(
       name = "interactive",
       params = NULL,
       ref = "123",
-      instance = "production")))
+      instance = "production",
+      changelog = NULL))))
 })
 
 test_that("orderly runner won't start if root not under version control", {
@@ -790,7 +803,7 @@ test_that("queue_status", {
                                     instance = "production")
   key3 <- runner$submit_task_report("count_param", parameters = list(
     time = 10, poll = 1
-  ))
+  ), changelog = "[internal] changelog message")
   ## Ensure all tasks have been added to queue
   testthat::try_again(5, {
     Sys.sleep(0.5)
@@ -807,28 +820,37 @@ test_that("queue_status", {
     key = key1,
     status = "running",
     version = id1,
-    name = "interactive",
-    params = NULL,
-    ref = NULL,
-    instance = NULL
+    inputs = list(
+      name = "interactive",
+      params = NULL,
+      ref = NULL,
+      instance = NULL,
+      changelog = NULL
+    )
   ))
   expect_equal(queue_status$tasks[[2]], list(
     key = key2,
     status = "queued",
     version = NULL,
-    name = "interactive",
-    params = NULL,
-    ref = "1234",
-    instance = "production"
+    inputs = list(
+      name = "interactive",
+      params = NULL,
+      ref = "1234",
+      instance = "production",
+      changelog = NULL
+    )
   ))
   expect_equal(queue_status$tasks[[3]], list(
     key = key3,
     status = "queued",
     version = NULL,
-    name = "count_param",
-    params = list(time = 10, poll = 1),
-    ref = NULL,
-    instance = NULL
+    inputs = list(
+      name = "count_param",
+      params = list(time = 10, poll = 1),
+      ref = NULL,
+      instance = NULL,
+      changelog = "[internal] changelog message"
+    )
   ))
 })
 


### PR DESCRIPTION
- [x] spec.md has been updated or doesn't need to updated

This will add info about parameters, git ref and db instance used in call to run report to the queue status endpoint. This will also add that info to the "queue" portion of the status endpoint too.

Do you think I should use `params` or `parameters` here? I have added `params` to be consistent with run request but the end goal for this is that is is returned from `orderly::orderly_queue_status` and orderly_run_remote uses `parameters` to refer to parameters. I could keep `params` here for consistency with report run endpoint and map to `parameters` in orderly for consistency with orderly interface.