### PR TITLE
Fix report status serialization after updating queue status format

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -261,15 +261,17 @@ endpoint_run <- function(runner) {
 
 target_status <- function(runner, key, output = FALSE) {
   res <- runner$status(key, output)
+  queue <- res$queue
+  if (is.null(queue)) {
+    queue <- list()
+  }
   list(
     key = scalar(res$key),
     status = scalar(res$status),
     version = scalar(res$version),
     start_time = scalar(res$start_time),
     output = res$output,
-    queue = lapply(res$queue, function(item) {
-      lapply(item, scalar)
-    })
+    queue = recursive_scalar(queue)
   )
 }
 
@@ -290,7 +292,7 @@ endpoint_queue_status <- function(runner) {
   porcelain::porcelain_endpoint$new(
     "GET", "/v1/queue/status/", target_queue_status,
     porcelain::porcelain_state(runner = runner),
-    returning = returning_json("QueueStatus.schema"))
+    returning = returning_json("QueueStatusResponse.schema"))
 }
 
 target_kill <- function(runner, key) {

--- a/inst/schema/QueueStatus.schema.json
+++ b/inst/schema/QueueStatus.schema.json
@@ -1,44 +1,37 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "QueueStatus",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "QueueStatus",
+  "type": "array",
+  "items": {
     "type": "object",
     "properties": {
-        "tasks": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "key": {"type": "string"},
-                    "status": {
-                        "$ref": "TaskStatus.schema.json"
-                    },
-                    "version": {
-                        "type": [ "string", "null" ]
-                    },
-                    "inputs" :{
-                        "type": "object",
-                        "properties": {
-                            "name": {"type": "string"},
-                            "params": { "$ref": "Parameters.schema.json" },
-                            "ref": {
-                                "type": [ "string", "null" ]
-                            },
-                            "instance": {
-                                "type": [ "string", "null" ]
-                            },
-                            "changelog": {
-                                "type": [ "string", "null" ]
-                            }
-                        },
-                        "required": ["name", "params", "ref", "instance",
-                                     "changelog"]
-                    }
-                },
-                "required": ["key", "status", "version", "inputs"],
-                "additionalProperties": false
-            }
-        }
+      "key": {"type": "string"},
+      "status": {
+        "$ref": "TaskStatus.schema.json"
+      },
+      "version": {
+        "type": [ "string", "null" ]
+      },
+      "inputs": {
+          "type": "object",
+          "properties": {
+              "name": {"type": "string"},
+              "params": { "$ref": "Parameters.schema.json" },
+              "ref": {
+                  "type": [ "string", "null" ]
+              },
+              "instance": {
+                  "type": [ "string", "null" ]
+              },
+              "changelog": {
+                  "type": [ "string", "null" ]
+              }
+          },
+          "required": ["name", "params", "ref", "instance",
+                       "changelog"]
+      }
     },
-    "required": [ "tasks" ],
+    "required": ["key", "status", "version", "inputs"],
     "additionalProperties": false
+  }
 }

--- a/inst/schema/QueueStatusResponse.schema.json
+++ b/inst/schema/QueueStatusResponse.schema.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "QueueStatusResponse",
+    "type": "object",
+    "properties": {
+        "tasks": { "$ref": "QueueStatus.schema.json" }
+    },
+    "required": [ "tasks" ],
+    "additionalProperties": false
+}

--- a/inst/schema/Status.schema.json
+++ b/inst/schema/Status.schema.json
@@ -40,24 +40,7 @@
                 }
             ]
         },
-        "queue": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "key": {"type": "string"},
-                    "status": {
-                        "$ref": "TaskStatus.schema.json"
-                    },
-                    "name": {"type": "string"},
-                    "version": {
-                        "type": [ "string", "null" ]
-                    }
-                },
-                "required": ["key", "status", "name", "version"],
-                "additionalProperties": false
-            }
-        }
+        "queue": { "$ref": "QueueStatus.schema.json" }
     },
     "required": ["key", "status", "version", "output", "queue"],
     "additionalProperties": false

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -319,14 +319,25 @@ test_that("status - queued", {
       list(
         key = "key-1",
         status = "running",
-        name = "minimal",
-        version = "20210310-123928-fef89bc7"
+        version = "20210310-123928-fef89bc7",
+        inputs = list(
+          name = "minimal",
+          params = list(timeout = 10, poll = 1),
+          ref = NULL,
+          instance = NULL,
+          changelog = "[internal] changelog"
+        )
       ),
       list(
         key = "key-2",
         status = "queued",
-        name = "minimal",
-        version = NULL)))
+        version = NULL,
+        inputs = list(
+          name = "minimal",
+          params = NULL,
+          ref = "123",
+          instance = "production",
+          changelog = NULL))))
 
   runner <- mock_runner(key, status)
 
@@ -342,14 +353,26 @@ test_that("status - queued", {
            list(
              key = scalar("key-1"),
              status = scalar("running"),
-             name = scalar("minimal"),
-             version = scalar("20210310-123928-fef89bc7")
+             version = scalar("20210310-123928-fef89bc7"),
+             inputs = list(
+               name = scalar("minimal"),
+               params = list(timeout = scalar(10), poll = scalar(1)),
+               ref = NULL,
+               instance = NULL,
+               changelog = scalar("[internal] changelog")
+             )
            ),
            list(
              key = scalar("key-2"),
              status = scalar("queued"),
-             name = scalar("minimal"),
-             version = NULL))))
+             version = NULL,
+             inputs = list(
+               name = scalar("minimal"),
+               params = NULL,
+               ref = scalar("123"),
+               instance = scalar("production"),
+               changelog = NULL
+             )))))
   expect_equal(mockery::mock_args(runner$status)[[1]], list(key, FALSE))
 
   ## endpoint


### PR DESCRIPTION
- [x] spec.md has been updated or doesn't need to updated

This will update the response for report status to use same format as queue status. Sorry I missed this in #99 