### PR TITLE
vimc-6539 get custom fields

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -24,6 +24,7 @@ build_api <- function(runner, path, backup_period = NULL,
   api$handle(endpoint_workflow_run(runner))
   api$handle(endpoint_workflow_status(runner))
   api$handle(endpoint_report_version_artefact(path))
+  api$handle(endpoint_report_versions_custom_fields(path))
   api$setDocs(FALSE)
   backup <- orderly_backup(runner$config, backup_period)
   api$registerHook("preroute", backup$check_backup)
@@ -488,15 +489,18 @@ endpoint_report_version_artefact <- function(path) {
 }
 
 
-target_report_versions_custom_fields <- function(path, ids) {
+target_report_versions_custom_fields <- function(path, versions) {
   db <- orderly::orderly_db("destination", root = path)
+  versions <- paste0("'", paste0(unlist(strsplit(versions, split = ",")),
+                                collapse = "','"),
+                     "'")
   sql <- paste(
     "select",
     "       report_version_custom_fields.key,",
     "       report_version_custom_fields.value,",
     "       report_version_custom_fields.report_version",
     "  from report_version_custom_fields",
-    sprintf(" where report_version in (%s)", ids),
+    sprintf(" where report_version in (%s)", versions),
     sep = "\n")
   dat <- DBI::dbGetQuery(db, sql)
 
@@ -514,7 +518,7 @@ endpoint_report_versions_custom_fields <- function(path) {
   porcelain::porcelain_endpoint$new(
     "GET", "/v1/report/version/customFields",
     target_report_versions_custom_fields,
-    porcelain::porcelain_input_query(ids = "string"),
+    porcelain::porcelain_input_query(versions = "string"),
     porcelain::porcelain_state(path = path),
     returning = returning_json("CustomFields.schema"))
 }

--- a/inst/schema/CustomFields.schema.json
+++ b/inst/schema/CustomFields.schema.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "CustomFields",
+    "type": "object",
+    "items": {
+        "type": "object",
+        "additionalProperties": true
+    }
+}

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -736,3 +736,42 @@ If a nonexistant key is given the response is
 ```
 
 Schema: [`ReportVersionArtefact.schema.json`](ReportVersionArtefact.schema.json)
+
+# GET /report/versions/customFields?versions=
+
+Get custom fields for a list of version ids.
+
+Response schema: [`CustomFields.schema.json`](CustomFields.schema.json)
+
+# Example
+
+`GET /report/versions/customFields?versions=20210629-231827-d35633fd,20210730-152428-14ad0fe7`
+
+```json
+{
+  "status": "success",
+  "errors": null,
+  "data": {
+    "20210629-231827-d35633fd": {
+      "requester": "Funder McFunderface",
+      "author": "Researcher McResearcherface",
+      "comment": "This is a comment"
+    },
+    "20210730-152428-14ad0fe7": {
+      "requester": "Funder McFunderface",
+      "author": "Researcher McResearcherface",
+      "comment": "This is a comment"
+    }
+  }
+}
+```
+
+If nonexistant ids are given the response is
+
+```json
+{
+  "status": "success",
+  "errors": null,
+  "data": {}
+}
+```

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -1104,14 +1104,11 @@ test_that("can retrieve custom fields", {
                               root = path, echo = FALSE)
   orderly::orderly_commit(id2, root = path)
 
-  ids <- paste(
-    paste0("'", id1, "'"),
-    paste0("'", id2, "'"), sep=",")
-
+  ids <- paste(id1, id2, sep = ",")
   data <- target_report_versions_custom_fields(path, ids)
 
   endpoint <- endpoint_report_versions_custom_fields(path)
-  res <- endpoint$run(ids = ids)
+  res <- endpoint$run(versions = ids)
 
   expect_true(res$validated)
   expect_equal(res$status_code, 200)

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -1092,3 +1092,37 @@ test_that("can retrieve information about artefacts", {
   expect_equal(res$data[[1]]$description, scalar("A summary table"))
   expect_equal(res$data[[1]]$files[[1]]$filename, scalar("summary.csv"))
 })
+
+
+test_that("can retrieve custom fields", {
+  path <- orderly_prepare_orderly_example("demo")
+  id1 <- orderly::orderly_run("other", parameters = list(nmin = 0.1),
+                             root = path, echo = FALSE)
+  orderly::orderly_commit(id1, root = path)
+
+  id2 <- orderly::orderly_run("minimal",
+                              root = path, echo = FALSE)
+  orderly::orderly_commit(id2, root = path)
+
+  ids <- paste(
+    paste0("'", id1, "'"),
+    paste0("'", id2, "'"), sep=",")
+
+  data <- target_report_versions_custom_fields(path, ids)
+
+  endpoint <- endpoint_report_versions_custom_fields(path)
+  res <- endpoint$run(ids = ids)
+
+  expect_true(res$validated)
+  expect_equal(res$status_code, 200)
+  expect_type(res$data, "list")
+  expect_equal(res$data, data)
+  expect_length(data, 2)
+  expect_equal(data[[1]], list(requester = scalar("ACME"),
+                               author = scalar("Dr Serious"),
+                               comment = scalar("This is another comment")))
+
+  expect_equal(data[[2]], list(requester = scalar("Funder McFunderface"),
+                               author = scalar("Researcher McResearcherface"),
+                               comment = scalar("This is a comment")))
+})


### PR DESCRIPTION
Adds `GET /report/version/customfields?versions=versionList` as per spec here:
https://mrc-ide.myjetbrains.com/youtrack/issue/VIMC-6539
- [x] spec.md has been updated or doesn't need to updated
