### PR TITLE
vimc-6541 add endpoint to get version list for report

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -486,3 +486,24 @@ endpoint_report_version_artefact <- function(path) {
     porcelain::porcelain_state(path = path),
     returning = returning_json("ReportVersionArtefact.schema"))
 }
+
+
+target_report_versions <- function(path, name) {
+  db <- orderly::orderly_db("destination", root = path)
+  sql <- paste(
+    "select report_version.id",
+    "from report_version",
+    "where report_version.report = $1",
+    sep = "\n")
+  dat <- DBI::dbGetQuery(db, sql, name)
+  dat[, 'id']
+}
+
+
+endpoint_report_versions <- function(path) {
+  porcelain::porcelain_endpoint$new(
+    "GET", "/v1/report/<name>",
+    target_report_versions,
+    porcelain::porcelain_state(path = path),
+    returning = returning_json("VersionIds.schema"))
+}

--- a/R/api.R
+++ b/R/api.R
@@ -496,7 +496,7 @@ target_report_versions <- function(path, name) {
     "where report_version.report = $1",
     sep = "\n")
   dat <- DBI::dbGetQuery(db, sql, name)
-  dat[, 'id']
+  dat[, "id"]
 }
 
 

--- a/inst/schema/VersionIds.schema.json
+++ b/inst/schema/VersionIds.schema.json
@@ -1,0 +1,7 @@
+{
+  "id": "VersionIds",
+  "type": "array",
+  "items": {
+    "type": "string"
+  }
+}

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -736,3 +736,19 @@ If a nonexistant key is given the response is
 ```
 
 Schema: [`ReportVersionArtefact.schema.json`](ReportVersionArtefact.schema.json)
+
+# GET /report/:name
+
+Returns a list of version names for the named report.
+
+Schema: [`VersionIds.schema.json`](VersionIds.schema.json)
+
+## Example
+
+```json
+[
+    "20161006-142357-e80edf58",
+    "20161008-123121-59891d61",
+    "20161012-220715-756d55c8"
+  ]
+```

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -1092,3 +1092,29 @@ test_that("can retrieve information about artefacts", {
   expect_equal(res$data[[1]]$description, scalar("A summary table"))
   expect_equal(res$data[[1]]$files[[1]]$filename, scalar("summary.csv"))
 })
+
+
+test_that("can retrieve version list", {
+  path <- orderly_prepare_orderly_example("demo")
+  id1 <- orderly::orderly_run("other", parameters = list(nmin = 0.1),
+                             root = path, echo = FALSE)
+  orderly::orderly_commit(id1, root = path)
+
+  id2 <- orderly::orderly_run("other", parameters = list(nmin = 0.1),
+                             root = path, echo = FALSE)
+  orderly::orderly_commit(id2, root = path)
+
+  id3 <- orderly::orderly_run("minimal",
+                             root = path, echo = FALSE)
+  orderly::orderly_commit(id3, root = path)
+
+  data <- target_report_versions(path, "other")
+  expect_equal(data, c(id1, id2))
+
+  endpoint <- endpoint_report_versions(path)
+  res <- endpoint$run(name = "other")
+
+  expect_true(res$validated)
+  expect_equal(res$status_code, 200)
+  expect_equal(res$data, c(id1, id2))
+})


### PR DESCRIPTION
The requirement for this was that OW should be able to check that a report exists: https://mrc-ide.myjetbrains.com/youtrack/issue/VIMC-6541

It seemed to me that implementing an endpoint which lists versions of a named report will suffice for that purpose while also being needed by OW elsewhere (e.g. to support this OW endpoint: https://github.com/vimc/orderly-web/blob/master/docs/spec/spec.md#get-reportsname)

So this PR adds:

`GET /report/:name` 

returning a list of version ids. If the list is empty, the report "doesn't exist" in the sense required by OW.