### PR TITLE
vimc-6542 add endpoint to get parameters for versions

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -25,6 +25,7 @@ build_api <- function(runner, path, backup_period = NULL,
   api$handle(endpoint_workflow_status(runner))
   api$handle(endpoint_report_version_artefact(path))
   api$handle(endpoint_report_versions_custom_fields(path))
+  api$handle(endpoint_report_versions_params(path))
   api$setDocs(FALSE)
   backup <- orderly_backup(runner$config, backup_period)
   api$registerHook("preroute", backup$check_backup)
@@ -523,4 +524,39 @@ endpoint_report_versions_custom_fields <- function(path) {
     porcelain::porcelain_input_query(versions = "string"),
     porcelain::porcelain_state(path = path),
     returning = returning_json("CustomFields.schema"))
+}
+
+
+target_report_versions_params <- function(path, versions) {
+  db <- orderly::orderly_db("destination", root = path)
+  versions <- paste0("'", paste0(unlist(strsplit(versions, split = ",")),
+                                 collapse = "','"),
+                     "'")
+  sql <- paste(
+    "select",
+    "       parameters.report_version,",
+    "       parameters.name,",
+    "       parameters.value",
+    "  from parameters",
+    sprintf(" where parameters.report_version in (%s)", versions),
+    sep = "\n")
+  dat <- DBI::dbGetQuery(db, sql)
+
+  process <- function(x) {
+    vals <- lapply(as.list(x$value), function(y) scalar(y))
+    names(vals) <- x$name
+    vals
+  }
+
+  lapply(split(dat, dat$report_version), process)
+}
+
+
+endpoint_report_versions_params <- function(path) {
+  porcelain::porcelain_endpoint$new(
+    "GET", "/v1/report/version/parameters",
+    target_report_versions_params,
+    porcelain::porcelain_input_query(versions = "string"),
+    porcelain::porcelain_state(path = path),
+    returning = returning_json("Parameters.schema"))
 }

--- a/R/api.R
+++ b/R/api.R
@@ -574,7 +574,7 @@ target_report_versions_params <- function(path, versions) {
 
 endpoint_report_versions_params <- function(path) {
   porcelain::porcelain_endpoint$new(
-    "GET", "/v1/report/version/parameters",
+    "GET", "/v1/reports/versions/parameters",
     target_report_versions_params,
     porcelain::porcelain_input_query(versions = "string"),
     porcelain::porcelain_state(path = path),

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -775,3 +775,38 @@ If nonexistant ids are given the response is
   "data": {}
 }
 ```
+
+# GET /report/versions/parameters?versions=
+
+Get parameters for a list of version ids.
+
+Response schema: [`Parameters.schema.json`](Parameters.schema.json)
+
+# Example
+
+`GET /report/versions/parameters?versions=20210629-231827-d35633fd,20210730-152428-14ad0fe7`
+
+```json
+{
+  "status": "success",
+  "errors": null,
+  "data": {
+    "20210629-231827-d35633fd": {
+      "nmin": "0.1"
+    },
+    "20210730-152428-14ad0fe7": {
+      "disease": "YF"
+    }
+  }
+}
+```
+
+If non-existent ids are given the response is
+
+```json
+{
+  "status": "success",
+  "errors": null,
+  "data": {}
+}
+```

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -792,7 +792,7 @@ If non-existent ids are given the response is
 }
 ```
 
-# GET /report/versions/parameters?versions=
+# GET /reports/versions/parameters?versions=
 
 Get parameters for a list of version ids.
 
@@ -800,7 +800,7 @@ Response schema: [`Parameters.schema.json`](Parameters.schema.json)
 
 # Example
 
-`GET /report/versions/parameters?versions=20210629-231827-d35633fd,20210730-152428-14ad0fe7`
+`GET /reports/versions/parameters?versions=20210629-231827-d35633fd,20210730-152428-14ad0fe7`
 
 ```json
 {

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -1146,3 +1146,29 @@ test_that("can retrieve custom fields", {
                                author = scalar("Researcher McResearcherface"),
                                comment = scalar("This is a comment")))
 })
+
+
+test_that("can retrieve parameters for versions", {
+  path <- orderly_prepare_orderly_example("demo")
+  id1 <- orderly::orderly_run("other", parameters = list(nmin = 0.1),
+                              root = path, echo = FALSE)
+  orderly::orderly_commit(id1, root = path)
+
+  id2 <- orderly::orderly_run("other", parameters = list(nmin = 0.5),
+                              root = path, echo = FALSE)
+  orderly::orderly_commit(id2, root = path)
+
+  ids <- paste(id1, id2, sep = ",")
+  data <- target_report_versions_params(path, ids)
+
+  endpoint <- endpoint_report_versions_params(path)
+  res <- endpoint$run(versions = ids)
+
+  expect_true(res$validated)
+  expect_equal(res$status_code, 200)
+  expect_type(res$data, "list")
+  expect_equal(res$data, data)
+  expect_length(data, 2)
+  expect_equal(data[[1]], list(nmin = scalar("0.1")))
+  expect_equal(data[[2]], list(nmin = scalar("0.5")))
+})


### PR DESCRIPTION
- [x] spec.md has been updated or doesn't need to updated

Adds `GET /report/versions/parameters?versions=20210629-231827-d35633fd,20210730-152428-14ad0fe7` for OW to replace 
https://github.com/vimc/orderly-web/blob/e5644edd85d45c89266068d2c88cd4ef8e8bc8e9/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/repositories/ReportRepository.kt#L386