### PR TITLE
vimc-6540 add custom fields endpoint

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -561,7 +561,7 @@ target_custom_fields <- function(path) {
 
 endpoint_custom_fields <- function(path) {
   porcelain::porcelain_endpoint$new(
-    "GET", "/v1/report/customFields",
+    "GET", "/v1/reports/customFields",
     target_custom_fields,
     porcelain::porcelain_state(path = path),
     returning = returning_json("CustomFields.schema"))

--- a/R/api.R
+++ b/R/api.R
@@ -25,6 +25,7 @@ build_api <- function(runner, path, backup_period = NULL,
   api$handle(endpoint_workflow_status(runner))
   api$handle(endpoint_report_version_artefact(path))
   api$handle(endpoint_report_versions_custom_fields(path))
+  api$handle(endpoint_custom_fields(path))
   api$setDocs(FALSE)
   backup <- orderly_backup(runner$config, backup_period)
   api$registerHook("preroute", backup$check_backup)
@@ -541,6 +542,27 @@ endpoint_report_versions_custom_fields <- function(path) {
     "GET", "/v1/report/version/customFields",
     target_report_versions_custom_fields,
     porcelain::porcelain_input_query(versions = "string"),
+    porcelain::porcelain_state(path = path),
+    returning = returning_json("CustomFieldsForVersions.schema"))
+}
+
+
+target_custom_fields <- function(path) {
+  db <- orderly::orderly_db("destination", root = path)
+
+  sql <- paste(
+    "select custom_fields.id",
+    "from custom_fields",
+    sep = "\n")
+  dat <- DBI::dbGetQuery(db, sql)
+  dat[, "id"]
+}
+
+
+endpoint_custom_fields <- function(path) {
+  porcelain::porcelain_endpoint$new(
+    "GET", "/v1/report/version/customFields",
+    target_custom_fields,
     porcelain::porcelain_state(path = path),
     returning = returning_json("CustomFields.schema"))
 }

--- a/R/api.R
+++ b/R/api.R
@@ -561,7 +561,7 @@ target_custom_fields <- function(path) {
 
 endpoint_custom_fields <- function(path) {
   porcelain::porcelain_endpoint$new(
-    "GET", "/v1/report/version/customFields",
+    "GET", "/v1/report/customFields",
     target_custom_fields,
     porcelain::porcelain_state(path = path),
     returning = returning_json("CustomFields.schema"))

--- a/inst/schema/CustomFieldsForVersions.schema.json
+++ b/inst/schema/CustomFieldsForVersions.schema.json
@@ -1,8 +1,9 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "CustomFields",
-    "type": "array",
+    "type": "object",
     "items": {
-        "type": "string"
+        "type": "object",
+        "additionalProperties": true
     }
 }

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -792,7 +792,7 @@ If non-existent ids are given the response is
 }
 ```
 
-# GET /customFields
+# GET /report/customFields
 
 Get custom fields for orderly instance
 

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -792,7 +792,7 @@ If non-existent ids are given the response is
 }
 ```
 
-# GET /report/customFields
+# GET /reports/customFields
 
 Get custom fields for orderly instance
 

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -757,7 +757,7 @@ Schema: [`VersionIds.schema.json`](VersionIds.schema.json)
 
 Get custom fields for a list of version ids.
 
-Response schema: [`CustomFields.schema.json`](CustomFields.schema.json)
+Response schema: [`CustomFieldsForVersions.schema.json`](CustomFieldsForVersions.schema.json)
 
 # Example
 
@@ -790,4 +790,16 @@ If non-existent ids are given the response is
   "errors": null,
   "data": {}
 }
+```
+
+# GET /customFields
+
+Get custom fields for orderly instance
+
+Response schema: [`CustomFields.schema.json`](CustomFields.schema.json)
+
+# Example
+
+```json
+["author", "requester"]
 ```

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -1176,6 +1176,7 @@ test_that("can retrieve custom fields for versions", {
 
 
 test_that("can retrieve custom fields", {
+  path <- orderly_prepare_orderly_example("demo")
   data <- target_custom_fields(path)
   endpoint <- endpoint_custom_fields(path)
   res <- endpoint$run()

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -1144,7 +1144,7 @@ test_that("can retrieve version list", {
 })
 
 
-test_that("can retrieve custom fields", {
+test_that("can retrieve custom fields for versions", {
   path <- orderly_prepare_orderly_example("demo")
   id1 <- orderly::orderly_run("other", parameters = list(nmin = 0.1),
                              root = path, echo = FALSE)
@@ -1172,4 +1172,18 @@ test_that("can retrieve custom fields", {
   expect_equal(data[[2]], list(requester = scalar("Funder McFunderface"),
                                author = scalar("Researcher McResearcherface"),
                                comment = scalar("This is a comment")))
+})
+
+
+test_that("can retrieve custom fields", {
+  data <- target_custom_fields(path)
+  endpoint <- endpoint_custom_fields(path)
+  res <- endpoint$run()
+
+  expect_true(res$validated)
+  expect_equal(res$status_code, 200)
+  expect_type(res$data, "character")
+  expect_equal(res$data, data)
+  expect_length(data, 3)
+  expect_equal(data, c("author", "comment", "requester"))
 })


### PR DESCRIPTION
- [x] spec.md has been updated or doesn't need to updated

New endpoint that gets a simple array of custom field names, for use by OW.