### PR TITLE
Build image that uses mrc-3169

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM vimc/orderly:master
+FROM vimc/orderly:mrc-3169
 
 RUN apt-get update || apt-get update && apt-get install -y \
   libcurl4-openssl-dev \


### PR DESCRIPTION
- [x] spec.md has been updated or doesn't need to updated
