### PR TITLE
vimc-6612 implement correct artefact endpoint

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -24,7 +24,7 @@ build_api <- function(runner, path, backup_period = NULL,
   api$handle(endpoint_workflow_run(runner))
   api$handle(endpoint_workflow_status(runner))
   api$handle(endpoint_report_versions(path))
-  api$handle(endpoint_report_version_artefact(path))
+  api$handle(endpoint_report_version_artefact_hashes(path))
   api$handle(endpoint_report_versions_custom_fields(path))
   api$handle(endpoint_custom_fields(path))
   api$handle(endpoint_report_versions_params(path))
@@ -452,46 +452,31 @@ check_timeout <- function(runner, rate_limit = 2 * 60) {
 }
 
 
-target_report_version_artefact <- function(path, name, id) {
+target_report_version_artefact_hashes <- function(path, name, id) {
   db <- orderly::orderly_db("destination", root = path)
   get_report_version(db, name, id)
   sql <- paste(
     "select",
-    "       report_version_artefact.'order' as id,",
-    "       report_version_artefact.format,",
-    "       report_version_artefact.description,",
     "       file_artefact.filename,",
-    "       file.size",
-    "  from report_version_artefact",
-    "  join file_artefact",
+    "       file_artefact.file_hash",
+    "  from file_artefact",
+    "  join report_version_artefact",
     "    on file_artefact.artefact = report_version_artefact.id",
-    "  join file",
-    "    on file.hash = file_artefact.file_hash",
-    " where report_version = $1",
-    " order by 'order'",
+    " where report_version_artefact.report_version = $1",
     sep = "\n")
   dat <- DBI::dbGetQuery(db, sql, id)
-
-  ## Bit of a pain to prepare this for serialisation nicely:
-  process <- function(x) {
-    list(id = scalar(x$id[[1]]),
-         format = scalar(x$format[[1]]),
-         description = scalar(x$description[[1]]),
-         files = Map(function(filename, size)
-           list(filename = scalar(filename), size = scalar(size)),
-           x$filename, x$size, USE.NAMES = FALSE))
-  }
-
-  lapply(unname(split(dat, dat$id)), process)
+  res <- lapply(dat[, 2], function(x) scalar(x))
+  names(res) <- dat[, 1]
+  res
 }
 
 
-endpoint_report_version_artefact <- function(path) {
+endpoint_report_version_artefact_hashes <- function(path) {
   porcelain::porcelain_endpoint$new(
     "GET", "/v1/reports/<name>/versions/<id>/artefacts/",
-    target_report_version_artefact,
+    target_report_version_artefact_hashes,
     porcelain::porcelain_state(path = path),
-    returning = returning_json("ReportVersionArtefact.schema"))
+    returning = returning_json("Artefacts.schema"))
 }
 
 

--- a/inst/schema/Artefacts.schema.json
+++ b/inst/schema/Artefacts.schema.json
@@ -1,5 +1,9 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "Artefact",
-    "type": [ "object" ]
+    "type": [ "object" ],
+    "additionalProperties": {
+        "type": "string",
+        "pattern": "[0-9a-f]{32}"
+    }
 }

--- a/inst/schema/Artefacts.schema.json
+++ b/inst/schema/Artefacts.schema.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "Artefact",
+    "type": [ "object" ]
+}

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -666,7 +666,7 @@ Response schema: [`WorkflowStatus.schema.json`](WorkflowStatus.schema.json)
 
 ## GET /reports/:name/versions/:id/artefacts
 
-Get information about artefacts for a report.
+Get a dictionary of artefact names to hashes.
 Returns a 404 if the provided report name-version combination does not exist.
 
 ## Example
@@ -675,56 +675,13 @@ Returns a 404 if the provided report name-version combination does not exist.
 {
   "status": "success",
   "errors": null,
-  "data": [
-    {
-      "id": 1,
-      "format": "data",
-      "description": "raw export",
-      "files": [
-        {
-          "filename": "all.csv",
-          "size": 801
-        }
-      ]
-    },
-    {
-      "id": 2,
-      "format": "data",
-      "description": "the subset we care most about",
-      "files": [
-        {
-          "filename": "subset.csv",
-          "size": 127
-        }
-      ]
-    },
-    {
-      "id": 3,
-      "format": "staticgraph",
-      "description": "plot of all data",
-      "files": [
-        {
-          "filename": "all.png",
-          "size": 9866
-        }
-      ]
-    },
-    {
-      "id": 4,
-      "format": "staticgraph",
-      "description": "plot of a subset of the data",
-      "files": [
-        {
-          "filename": "subset.png",
-          "size": 4291
-        }
-      ]
-    }
-  ]
+  "data": {
+    "mygraph.png": "7360cb2eed3327ff8a677b3598ed7343"
+  }
 }
 ```
 
-Schema: [`ReportVersionArtefact.schema.json`](ReportVersionArtefact.schema.json)
+Schema: [`Artefacts.schema.json`](Artefacts.schema.json)
 
 # GET /reports/:name
 

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -664,11 +664,10 @@ Response schema: [`WorkflowStatus.schema.json`](WorkflowStatus.schema.json)
 }
 ```
 
-## GET /reports/versions/:id/artefacts
+## GET /reports/:name/versions/:id/artefacts
 
 Get information about artefacts for a report.
-
-Note that the report name is not needed here.
+Returns a 404 if the provided report name-version combination does not exist.
 
 ## Example
 
@@ -725,21 +724,11 @@ Note that the report name is not needed here.
 }
 ```
 
-If a nonexistant key is given the response is
-
-```json
-{
-  "status": "success",
-  "errors": null,
-  "data": []
-}
-```
-
 Schema: [`ReportVersionArtefact.schema.json`](ReportVersionArtefact.schema.json)
 
 # GET /reports/:name
 
-Returns a list of version names for the named report.
+Returns a list of version names for the named report. Returns 404 if no versions exist.
 
 Schema: [`VersionIds.schema.json`](VersionIds.schema.json)
 

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -1094,25 +1094,20 @@ test_that("endpoint_report_info returns parameter info", {
 })
 
 
-test_that("can retrieve information about artefacts", {
+test_that("can retrieve artefact hashes", {
   path <- orderly_prepare_orderly_example("demo")
   id <- orderly::orderly_run("other", parameters = list(nmin = 0.1),
                              root = path, echo = FALSE)
   orderly::orderly_commit(id, root = path)
-  data <- target_report_version_artefact(path, "other", id)
-
-  endpoint <- endpoint_report_version_artefact(path)
+  endpoint <- endpoint_report_version_artefact_hashes(path)
   res <- endpoint$run(name = "other", id = id)
 
   expect_true(res$validated)
   expect_equal(res$status_code, 200)
   expect_type(res$data, "list")
-  ## No need to check the format of the data all over as that's
-  ## duplicated by the schema check.  But here, check the first file
-  ## is indeed first:
-  expect_equal(res$data[[1]]$id, scalar(1L))
-  expect_equal(res$data[[1]]$description, scalar("A summary table"))
-  expect_equal(res$data[[1]]$files[[1]]$filename, scalar("summary.csv"))
+  expect_equal(res$data,
+               list("summary.csv"=scalar("08a4566d063098080bfd318f675926f2"),
+                    "graph.png"=scalar("c00a51d4f397eac73c2833795224ca74")))
 })
 
 

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -1105,9 +1105,8 @@ test_that("can retrieve artefact hashes", {
   expect_true(res$validated)
   expect_equal(res$status_code, 200)
   expect_type(res$data, "list")
-  expect_equal(res$data,
-               list("summary.csv"=scalar("08a4566d063098080bfd318f675926f2"),
-                    "graph.png"=scalar("c00a51d4f397eac73c2833795224ca74")))
+  expect_equal(names(res$data), c("summary.csv", "graph.png"))
+  expect_equal(res$data[[1]], scalar("08a4566d063098080bfd318f675926f2"))
 })
 
 

--- a/tests/testthat/test-z-integration.R
+++ b/tests/testthat/test-z-integration.R
@@ -710,8 +710,8 @@ test_that("can get report version artefacts", {
   url <- paste0("/v1/reports/minimal/versions/", id, "/artefacts/")
   r <- content(httr::GET(server$api_url(url)))
   expect_equal(r$status, "success")
-  expect_equal(r$data[[1]]$id, scalar(1L))
-  expect_equal(r$data[[1]]$description, scalar("A graph of things"))
+  expect_type(r$data, "list")
+  expect_equal(names(r$data), c("summary.csv", "graph.png"))
   expect_equal(r$errors, NULL)
 })
 

--- a/tests/testthat/test-z-integration.R
+++ b/tests/testthat/test-z-integration.R
@@ -711,7 +711,7 @@ test_that("can get report version artefacts", {
   r <- content(httr::GET(server$api_url(url)))
   expect_equal(r$status, "success")
   expect_type(r$data, "list")
-  expect_equal(names(r$data), c("summary.csv", "graph.png"))
+  expect_equal(names(r$data), "mygraph.png")
   expect_equal(r$errors, NULL)
 })
 


### PR DESCRIPTION
~~Should be merged after https://github.com/vimc/orderly.server/pull/108~~

We don't actually need the artefact endpoint as previously implemented. What we need is the equivalent of this OW endpoint:
https://github.com/vimc/orderly-web/blob/master/docs/spec/spec.md#get-reportsnameversionsversionartefacts

- [x] spec.md has been updated or doesn't need to updated
