### PR TITLE
vimc-6659 endpoint to get resource hashes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly.server
 Title: Serve Orderly
-Version: 0.3.27
+Version: 0.3.28
 Description: Run orderly reports as a server.
 License: MIT + file LICENSE
 Author: Rich FitzJohn

--- a/R/api.R
+++ b/R/api.R
@@ -27,6 +27,7 @@ build_api <- function(runner, path, backup_period = NULL,
   api$handle(endpoint_report_version_details(path))
   api$handle(endpoint_report_version_artefact_hashes(path))
   api$handle(endpoint_report_version_data_hashes(path))
+  api$handle(endpoint_report_version_resource_hashes(path))
   api$handle(endpoint_report_versions_custom_fields(path))
   api$handle(endpoint_custom_fields(path))
   api$handle(endpoint_report_versions_params(path))
@@ -607,6 +608,31 @@ endpoint_report_version_data_hashes <- function(path) {
   porcelain::porcelain_endpoint$new(
     "GET", "/v1/reports/<name>/versions/<id>/data/",
     target_report_version_data_hashes,
+    porcelain::porcelain_state(path = path),
+    returning = returning_json("HashDictionary.schema"))
+}
+
+target_report_version_resource_hashes <- function(path, name, id) {
+  db <- orderly::orderly_db("destination", root = path)
+  get_report_version(db, name, id)
+  sql <- paste(
+    "select",
+    "       file_input.filename,",
+    "       file_input.file_hash",
+    "  from file_input",
+    " where file_input.report_version = $1",
+    " and file_input.file_purpose = 'resource'",
+    sep = "\n")
+  dat <- DBI::dbGetQuery(db, sql, id)
+  res <- lapply(dat[, 2], function(x) scalar(x))
+  names(res) <- dat[, 1]
+  res
+}
+
+endpoint_report_version_resource_hashes <- function(path) {
+  porcelain::porcelain_endpoint$new(
+    "GET", "/v1/reports/<name>/versions/<id>/resources/",
+    target_report_version_resource_hashes,
     porcelain::porcelain_state(path = path),
     returning = returning_json("HashDictionary.schema"))
 }

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -765,6 +765,25 @@ Schema: [`HashDictionary.schema.json`](HashDictionary.schema.json)
 }
 ```
 
+## GET /reports/:name/versions/:id/resources
+
+Get a dictionary of resource names to hashes.
+Returns a 404 if the provided report name-version combination does not exist.
+
+Schema: [`HashDictionary.schema.json`](HashDictionary.schema.json)
+
+## Example
+
+```json
+{
+  "status": "success",
+  "errors": null,
+  "data": {
+    "meta/data.csv": "7360cb2eed3327ff8a677b3598ed7343"
+  }
+}
+```
+
 ## GET /reports/versions/customFields?versions=
 
 Get custom fields for a list of version ids.

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -1139,6 +1139,36 @@ test_that("data returns 404 if report version does not exist", {
 })
 
 
+test_that("can return resource hashes", {
+  path <- orderly_prepare_orderly_example("demo")
+  id <- orderly::orderly_run("use_resource",
+                             root = path, echo = FALSE)
+  orderly::orderly_commit(id, root = path)
+  endpoint <- endpoint_report_version_resource_hashes(path)
+  res <- endpoint$run(name = "use_resource", id = id)
+
+  expect_true(res$validated)
+  expect_equal(res$status_code, 200)
+  expect_type(res$data, "list")
+  expect_equal(res$data,
+               list("meta/data.csv" =
+                      scalar("0bec5bf6f93c547bc9c6774acaf85e1a")))
+})
+
+
+test_that("resources returns 404 if report version does not exist", {
+  path <- orderly_prepare_orderly_example("demo")
+  endpoint <- endpoint_report_version_resource_hashes(path)
+  res <- endpoint$run(name = "use_resource", id = "badid")
+
+  expect_equal(res$status_code, 404)
+  expect_equal(res$data, NULL)
+  expect_equal(res$error$data[[1]],
+               list(error = scalar("NONEXISTENT_REPORT_VERSION"),
+                    detail = scalar("Unknown report version 'badid'")))
+})
+
+
 test_that("can retrieve version list", {
   path <- orderly_prepare_orderly_example("demo")
   id1 <- orderly::orderly_run("other", parameters = list(nmin = 0.1),

--- a/tests/testthat/test-z-integration.R
+++ b/tests/testthat/test-z-integration.R
@@ -738,7 +738,7 @@ test_that("can get report version data hashes", {
 
 
 test_that("can get report version resource hashes", {
-  path <- orderly_prepare_orderly_git_example()[["local"]]
+  path <- orderly_prepare_orderly_example(name = "demo", git = TRUE)
   server <- start_test_server(path)
   id <- orderly::orderly_run("use_resource", root = path, echo = FALSE)
   orderly::orderly_commit(id, root = path)

--- a/tests/testthat/test-z-integration.R
+++ b/tests/testthat/test-z-integration.R
@@ -721,7 +721,7 @@ test_that("can get report version details", {
 })
 
 
-test_that("can get report version data", {
+test_that("can get report version data hashes", {
   path <- orderly_prepare_orderly_git_example()[["local"]]
   server <- start_test_server(path)
   id <- orderly::orderly_run("minimal", root = path, echo = FALSE)
@@ -733,5 +733,21 @@ test_that("can get report version data", {
   expect_equal(r$status, "success")
   expect_type(r$data, "list")
   expect_equal(names(r$data), "dat")
+  expect_equal(r$errors, NULL)
+})
+
+
+test_that("can get report version resource hashes", {
+  path <- orderly_prepare_orderly_git_example()[["local"]]
+  server <- start_test_server(path)
+  id <- orderly::orderly_run("use_resource", root = path, echo = FALSE)
+  orderly::orderly_commit(id, root = path)
+  on.exit(server$stop())
+
+  url <- paste0("/v1/reports/use_resource/versions/", id, "/resources/")
+  r <- content(httr::GET(server$api_url(url)))
+  expect_equal(r$status, "success")
+  expect_type(r$data, "list")
+  expect_equal(names(r$data), "meta/data.csv")
   expect_equal(r$errors, NULL)
 })


### PR DESCRIPTION
~~Builds off https://github.com/vimc/orderly.server/pull/111~~

In service of https://github.com/vimc/orderly-web/blob/master/docs/spec/spec.md#get-reportsnameversionsversionresources

- [x] spec.md has been updated or doesn't need to updated
