### PR TITLE
Update workflow summary endpoint to be able to take NULL ref

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly.server
 Title: Serve Orderly
-Version: 0.3.28
+Version: 0.3.29
 Description: Run orderly reports as a server.
 License: MIT + file LICENSE
 Author: Rich FitzJohn

--- a/inst/schema/WorkflowSummaryRequest.schema.json
+++ b/inst/schema/WorkflowSummaryRequest.schema.json
@@ -4,7 +4,7 @@
     "type": "object",
     "properties": {
         "reports": { "$ref": "WorkflowReports.schema.json" },
-        "ref": { "type": "string" }
+        "ref": { "type": [ "string", "null" ] }
     },
     "required": ["reports"],
     "additionalProperties": true

--- a/inst/schema/WorkflowSummaryResponse.schema.json
+++ b/inst/schema/WorkflowSummaryResponse.schema.json
@@ -4,7 +4,7 @@
     "type": "object",
     "properties": {
         "reports": { "$ref": "WorkflowReports.schema.json" },
-        "ref": { "type": "string" },
+        "ref": { "type": [ "string", "null" ] },
         "missing_dependencies": {
             "type": "object",
             "additionalProperties": {


### PR DESCRIPTION
- [x] spec.md has been updated or doesn't need to updated


Getting a failure on naomi-orderly, this endpoint is always failing

from naomi-web logs
```
[qtp1976447072-63] ERROR org.vaccineimpact.orderlyweb.app_start.ErrorHandler - An unhandled exception occurred
java.lang.NullPointerException
	at org.vaccineimpact.orderlyweb.controllers.web.WorkflowRunController.getWorkflowRunStatus(WorkflowRunController.kt:182)
	at jdk.internal.reflect.GeneratedMethodAccessor20.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.vaccineimpact.orderlyweb.app_start.ActionResolver.invokeControllerAction(ActionResolver.kt:29)
	at org.vaccineimpact.orderlyweb.app_start.Router.getWrappedRoute$lambda-2(Router.kt:104)
	at spark.ResponseTransformerRouteImpl$1.handle(ResponseTransformerRouteImpl.java:47)
	at spark.http.matching.Routes.execute(Routes.java:61)
	at spark.http.matching.MatcherFilter.doFilter(MatcherFilter.java:134)
	at spark.embeddedserver.jetty.JettyHandler.doHandle(JettyHandler.java:50)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1584)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
	at org.eclipse.jetty.server.Server.handle(Server.java:501)
	at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:383)
	at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:556)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:375)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:273)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
	at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:336)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:313)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:171)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:129)
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:375)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:806)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:938)
	at java.base/java.lang.Thread.run(Thread.java:829)
[qtp1976447072-63] WARN org.vaccineimpact.orderlyweb.app_start.ErrorHandler - For request /workflows/durable_northerncardinals/status, a UnexpectedError occurred with the following problems: [An unexpected error occurred. Please contact support at r.ashton@imperial.ac.uk and quote this code: udf-oae-zfh]
```

Can see in orderly.server logs
```
{"level":400,"timestamp":"2022-08-17 10:15:24","logger":"orderly.server","caller":"postroute","msg":"request GET /v1/workflow/unaesthetical_viperfish/status/"}
{"level":400,"timestamp":"2022-08-17 10:15:24","logger":"orderly.server","caller":"postserialize","msg":"response GET /v1/workflow/unaesthetical_viperfish/status/ => 200 (6516 bytes)"}
{"level":400,"timestamp":"2022-08-17 10:15:24","logger":"orderly.server","caller":"postroute","msg":"request POST /v1/workflow/summary/"}
{"level":400,"timestamp":"2022-08-17 10:15:24","logger":"orderly.server","caller":"postserialize","msg":"response POST /v1/workflow/summary/ => 400 (188 bytes)"}
{"level":200,"timestamp":"2022-08-17 10:15:24","logger":"orderly.server","caller":"postserialize","msg":"error","errors":[{"error":"INVALID_INPUT","detail":"Error parsing body (for 'body'): 1 error validating json:\n\t- /ref (#/properties/ref/type): must be string"}],"method":"POST","path":"/v1/workflow/summary/","query":[],"headers":{"accept":"application/json","accept-encoding":"gzip","connection":"Keep-Alive","content-length":"3661","content-type":"application/json; charset=utf-8","host":"naomi_orderly:8321","user-agent":"okhttp/4.8.1"},"body":"{\"reports\":[{\"name\":\"ago_data_survey\",\"params\":{\"version\":\"2022\",\"iso3\":\"AGO\"}},{\"name\":\"bdi_data_survey\",\"params\":{\"version\":\"2022\",\"iso3\":\"BDI\"}},{\"name\":\"ben_raw_survey_ben2012dhs\",\"params\":{\"version\":\"2022\"}},{\"name\":\"ben_data_survey\",\"params\":{\"version\":\"2022\"}},{\"name\":\"bfa_data_survey\",\"params\":{\"version\":\"2022\",\"iso3\":\"BFA\"}},{\"name\":\"bwa_data_survey_bwa2008bais\",\"params\":{\"version\":\"2022\",\"iso3\":\"BWA\"}},{\"name\":\"bwa_raw_survey_bwa2013bais\",\"params\":{\"version\":\"2022\"}},{\"name\":\"bwa_data_survey_bwa2013bais\",\"params\":{\"version\":\"2022\",\"iso3\":\"BWA\"}},{\"name\":\"cmr_data_survey_dhs\",\"params\":{\"version\":\"2022\",\"iso3\":\"CMR\"}},{\"name\":\"cmr_data_survey_phia\",\"params\":{\"version\":\"2022\",\"iso3\":\"CMR\"}},{\"name\":\"cog_data_survey\",\"params\":{\"version\":\"2022\",\"iso3\":\"COG\"}},{\"name\":\"eth_data_survey-dhs\",\"params\":{\"version\":\"2022\",\"iso3\":\"ETH\"}},{\"name\":\"eth_data_survey-phia\",\"params\":{\"version\":\"2022\",\"iso3\":\"ETH\"}},{\"name\":\"eth_data_survey\",\"params\":{\"version\":\"2022\",\"iso3\":\"ETH\"}},{\"name\":\"gab_data_survey\",\"params\":{\"version\":\"2022\",\"iso3\":\"GAB\"}},{\"name\":\"gha_data_survey\",\"params\":{\"version\":\"2022\",\"iso3\":\"GHA\"}},{\"name\":\"gin_data_survey\",\"params\":{\"version\":\"2022\",\"iso3\":\"GIN\"}},{\"name\":\"gmb_data_survey\",\"params\":{\"version\":\"2022\",\"iso3\":\"GMB\"}},{\"name\":\"hti_data_survey_hti2019phia\",\"params\":{\"version\":\"2022\",\"iso3\":\"HTI\"}},{\"name\":\"hti_data_survey-dhs\",\"params\":{\"version\":\"2022\",\"iso3\":\"HTI\"}},{\"name\":\"hti_data_survey\",\"params\":{\"version\":\"2022\",\"iso3\":\"HTI\"}},{\"name\":\"ken_data_survey\",\"params\":{\"version\":\"2022\",\"iso3\":\"KEN\"}},{\"name\":\"lso_data_survey_dhs\",\"params\":{\"version\":\"2022\",\"iso3\":\"LSO\"}},{\"name\":\"lso_data_survey_phia\",\"params\":{\"version\":\"2022\",\"iso3\":\"LSO\"}},{\"name\":\"lso_data_survey\",\"params\":{\"version\":\"2022\",\"iso3\":\"LSO\"}},{\"name\":\"lbr_data_survey\",\"params\":{\"version\":\"2022\",\"iso3\":\"LBR\"}},{\"name\":\"mli_data_survey\",\"params\":{\"version\":\"2022\",\"iso3\":\"MLI\"}},{\"name\":\"moz_data_survey\",\"params\":{\"version\":\"2022\",\"iso3\":\"MOZ\"}},{\"name\":\"nga_data_survey_akais\",\"params\":{\"version\":\"2022\",\"iso3\":\"NGA\"}},{\"name\":\"nga_data_survey_kdais\",\"params\":{\"version\":\"2022\",\"iso3\":\"NGA\"}},{\"name\":\"nga_data_survey_naiis\",\"params\":{\"version\":\"2022\",\"iso3\":\"NGA\"}},{\"name\":\"nga_data_survey\",\"params\":{\"version\":\"2022\",\"iso3\":\"NGA\"}},{\"name\":\"nam_data_survey\",\"params\":{\"version\":\"2022\",\"iso3\":\"NAM\"}},{\"name\":\"ner_data_survey\",\"params\":{\"version\":\"2021\",\"iso3\":\"NER\"}},{\"name\":\"rwa_data_survey\",\"params\":{\"version\":\"2022\",\"iso3\":\"RWA\"}},{\"name\":\"sen_data_survey\",\"params\":{\"version\":\"2022\",\"iso3\":\"SEN\"}},{\"name\":\"sle_data_survey\",\"params\":{\"version\":\"2022\",\"iso3\":\"SLE\"}},{\"name\":\"swz_data_survey\",\"params\":{\"version\":\"2022\",\"iso3\":\"SWZ\"}},{\"name\":\"tcd_data_survey\",\"params\":{\"version\":\"2022\",\"iso3\":\"TCD\"}},{\"name\":\"tgo_data_survey\",\"params\":{\"version\":\"2022\",\"iso3\":\"TGO\"}},{\"name\":\"tza_data_survey\",\"params\":{\"version\":\"2022\",\"iso3\":\"TZA\"}},{\"name\":\"uga_data_survey_uga2017phia\",\"params\":{\"version\":\"2022\",\"iso3\":\"UGA\"}},{\"name\":\"uga_data_survey_uga2020phia\",\"params\":{\"version\":\"2022\",\"iso3\":\"UGA\"}},{\"name\":\"uga_data_survey\",\"params\":{\"version\":\"2022\"}},{\"name\":\"mwi_data\",\"params\":{\"version\":\"2022\",\"iso3\":\"MWI\"}},{\"name\":\"zmb_data_survey_dhs\",\"params\":{\"version\":\"2022\",\"iso3\":\"ZMB\"}},{\"name\":\"zmb_data_survey_phia\",\"params\":{\"version\":\"2022\",\"iso3\":\"ZMB\"}},{\"name\":\"zmb_data_survey\",\"params\":{\"version\":\"2022\",\"iso3\":\"ZMB\"}},{\"name\":\"zwe_data_survey_zwe2020phia\",\"params\":{\"version\":\"2022\",\"iso3\":\"ZWE\"}},{\"name\":\"zwe_data_survey-dhs\",\"params\":{\"version\":\"2022\",\"iso3\":\"ZWE\"}},{\"name\":\"zwe_data_survey-phia\",\"params\":{\"version\":\"2022\",\"iso3\":\"ZWE\"}},{\"name\":\"zwe_data_survey\",\"params\":{\"version\":\"2022\",\"iso3\":\"ZWE\"}}],\"ref\":null}"}
```

We're receiving `null` ref which is not currently being handled. This PR adds a test and fixes schema to take NULL ref.