### PR TITLE
Add support for passing empty string for branch and commit

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly.server
 Title: Serve Orderly
-Version: 0.3.29
+Version: 0.3.30
 Description: Run orderly reports as a server.
 License: MIT + file LICENSE
 Author: Rich FitzJohn

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Imports:
     jsonlite,
     lgr,
     orderly (>= 1.4.9),
-    porcelain (>= 0.1.8),
+    porcelain (>= 0.1.9),
     processx,
     redux,
     rrq (>= 0.5.6),

--- a/R/git.R
+++ b/R/git.R
@@ -152,10 +152,12 @@ git_latest_commit <- function(branch = "master", root = NULL) {
 }
 
 get_reports <- function(branch, commit, show_all, default_branch, root) {
-  list_all <- show_all || identical(branch, default_branch) ||
-    is.null(branch) || !nzchar(branch)
+  list_all <- show_all || identical(branch, default_branch) || is_empty(branch)
   if (list_all) {
-    if (is.null(commit) || !nzchar(commit)) {
+    if (is_empty(commit)) {
+      if (is_empty(branch)) {
+        branch <- default_branch
+      }
       commit <- git_latest_commit(branch, root = root)
     }
     reports <- git_run(c("ls-tree", "--name-only", "-d",

--- a/R/git.R
+++ b/R/git.R
@@ -183,7 +183,7 @@ get_reports <- function(branch, commit, show_all, default_branch, root) {
 get_report_parameters <- function(report, commit, root, branch = "master") {
   tryCatch({
     ## Default to latest commit from 'branch' if missing
-    if (is.null(commit)) {
+    if (is_empty(commit)) {
       commit <- git_latest_commit(branch, root = root)
     }
     yml <- git_run(

--- a/R/git.R
+++ b/R/git.R
@@ -152,9 +152,10 @@ git_latest_commit <- function(branch = "master", root = NULL) {
 }
 
 get_reports <- function(branch, commit, show_all, default_branch, root) {
-  list_all <- show_all || identical(branch, default_branch) || is.null(branch)
+  list_all <- show_all || identical(branch, default_branch) ||
+    is.null(branch) || !nzchar(branch)
   if (list_all) {
-    if (is.null(commit)) {
+    if (is.null(commit) || !nzchar(commit)) {
       commit <- git_latest_commit(branch, root = root)
     }
     reports <- git_run(c("ls-tree", "--name-only", "-d",

--- a/R/util.R
+++ b/R/util.R
@@ -183,3 +183,7 @@ key_value_collector <- function(init = list()) {
 }
 
 squote <- function(x) sprintf("'%s'", x)
+
+is_empty <- function(x) {
+  is.null(x) || is.na(x) || !nzchar(x)
+}

--- a/inst/schema/spec.md
+++ b/inst/schema/spec.md
@@ -323,7 +323,7 @@ Get metadata for Orderly Web report runner interface to control UI display
 List reports which can be run by Orderly Web. 
 
 Reports can be listed
-* With no branch or commit - lists all reports in src dir on latest commit on master branch
+* With no branch or commit (e.g. without params entirely or as branch=''&commit='') - lists all reports in src dir on latest commit on master branch
 * With a branch other than master & unmerged commit - lists all reports which have changes in them from this commit compared with master branch 
 * With a branch other than master (& optionally a commit) and param `show_all=true` to list all reports available on a branch for a certain commit. If commit is empty then this will use the most recent commit
 * With master branch and a commit - lists all reports in src dir on this commit

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -137,12 +137,16 @@ test_that("can get available reports for a branch & commit", {
   expect_equal(res$data, c("global", "minimal"))
 })
 
-test_that("can get available reports with empty branch & commit", {
+test_that("can get available reports with empty or NA branch & commit", {
   path <- orderly_prepare_orderly_git_example()
   runner <- mock_runner(root = path[["origin"]])
   endpoint <- endpoint_available_reports(runner)
 
   res <- endpoint$run("", "", TRUE)
+  expect_equal(res$status_code, 200)
+  expect_equal(res$data, c("global", "minimal"))
+
+  res <- endpoint$run(NA, NA)
   expect_equal(res$status_code, 200)
   expect_equal(res$data, c("global", "minimal"))
 })

--- a/tests/testthat/test-api-endpoints.R
+++ b/tests/testthat/test-api-endpoints.R
@@ -137,6 +137,16 @@ test_that("can get available reports for a branch & commit", {
   expect_equal(res$data, c("global", "minimal"))
 })
 
+test_that("can get available reports with empty branch & commit", {
+  path <- orderly_prepare_orderly_git_example()
+  runner <- mock_runner(root = path[["origin"]])
+  endpoint <- endpoint_available_reports(runner)
+
+  res <- endpoint$run("", "", TRUE)
+  expect_equal(res$status_code, 200)
+  expect_equal(res$data, c("global", "minimal"))
+})
+
 test_that("can get parameters for a report & commit", {
   path <- orderly_prepare_orderly_git_example()
   runner <- mock_runner(root = path[["origin"]])

--- a/tests/testthat/test-git.R
+++ b/tests/testthat/test-git.R
@@ -353,8 +353,13 @@ test_that("can get parameters from a report", {
   params <- get_report_parameters("other", other_commits$id, path[["local"]])
   expect_equal(params, list(nmin = NULL))
 
-  ## get report parameters defaults to latest commit if NULL
+  ## get report parameters defaults to latest commit if NULL or NA
   default_params <- get_report_parameters("minimal", NULL, path[["origin"]])
+  expect_equal(default_params, list(a = NULL,
+                                    b = list(default = "test"),
+                                    c = list(default = 2)))
+
+  default_params <- get_report_parameters("minimal", NA, path[["origin"]])
   expect_equal(default_params, list(a = NULL,
                                     b = list(default = "test"),
                                     c = list(default = 2)))

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -175,3 +175,10 @@ test_that("ordered_map_to_list", {
                "Corrupt ordered map (this should never happen)",
                fixed = TRUE)
 })
+
+test_that("is_empty", {
+  expect_true(is_empty(NULL))
+  expect_true(is_empty(NA))
+  expect_true(is_empty(""))
+  expect_false(is_empty("text"))
+})

--- a/tests/testthat/test-z-integration.R
+++ b/tests/testthat/test-z-integration.R
@@ -337,6 +337,11 @@ test_that("can get available reports", {
   server <- start_test_server(path[["local"]])
   on.exit(server$stop())
 
+  url <- "/reports/source?branch=&commit="
+  reports <- content(httr::GET(server$api_url(url)))
+  expect_equal(reports$status, "success")
+  expect_equal(reports$data, c("global", "minimal"))
+
   r <- content(httr::GET(server$api_url("/git/commits?branch=master")))
   expect_equal(r$status, "success")
 


### PR DESCRIPTION
- [x] spec.md has been updated or doesn't need to updated

This PR will
* Allow user to pass empty args for branch and commit to report source endpoint  i.e. as `/reports/source?branch=''&commit=''` or `/reports/source?branch=&commit?`
* Allow user to pass empty args for commit to report parameters endpoint i.e. as `/reports/other/parameters?commit=`