### PR TITLE
Ensure all endpoints handle NA query parameters

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly.server
 Title: Serve Orderly
-Version: 0.3.30
+Version: 0.3.31
 Description: Run orderly reports as a server.
 License: MIT + file LICENSE
 Author: Rich FitzJohn
@@ -14,7 +14,7 @@ Imports:
     jsonlite,
     lgr,
     orderly (>= 1.4.10),
-    porcelain (>= 0.1.9),
+    porcelain (>= 0.1.11),
     processx,
     redux,
     rrq (>= 0.5.6),

--- a/R/api.R
+++ b/R/api.R
@@ -628,7 +628,8 @@ endpoint_custom_fields <- function(path) {
 }
 
 target_report_versions_params <- function(path, versions) {
-  args <- set_param_defaults(target_report_versions_params, as.list(environment()))
+  args <- set_param_defaults(target_report_versions_params,
+                             as.list(environment()))
   list2env(args, envir = environment())
   db <- orderly::orderly_db("destination", root = path)
   get_parameters_for_versions(db, unlist(strsplit(versions, split = ",")))
@@ -696,7 +697,8 @@ target_report_version_changelog <- function(path,
                                             name,
                                             id,
                                             public_only = FALSE) {
-  args <- set_param_defaults(target_report_version_changelog, as.list(environment()))
+  args <- set_param_defaults(target_report_version_changelog,
+                             as.list(environment()))
   list2env(args, envir = environment())
   db <- orderly::orderly_db("destination", root = path)
   version <- get_report_version(db, name, id)

--- a/R/api.R
+++ b/R/api.R
@@ -128,6 +128,8 @@ endpoint_git_branches <- function(runner) {
 }
 
 target_git_commits <- function(runner, branch) {
+  args <- set_param_defaults(target_git_commits, as.list(environment()))
+  list2env(args, envir = environment())
   git_commits(branch, runner$root, runner$default_branch)
 }
 
@@ -141,21 +143,25 @@ endpoint_git_commits <- function(runner) {
 
 target_available_reports <- function(runner, branch = NULL, commit = NULL,
                                      show_all = FALSE) {
+  args <- set_param_defaults(target_available_reports, as.list(environment()))
+  list2env(args, envir = environment())
   get_reports(branch, commit, show_all, runner$default_branch, runner$root)
 }
 
 endpoint_available_reports <- function(runner) {
   porcelain::porcelain_endpoint$new(
     "GET", "/reports/source", target_available_reports,
-    porcelain::porcelain_input_query(branch = "string"),
-    porcelain::porcelain_input_query(commit = "string"),
-    porcelain::porcelain_input_query(show_all = "logical"),
+    porcelain::porcelain_input_query(branch = "string",
+                                     commit = "string",
+                                     show_all = "logical"),
     porcelain::porcelain_state(runner = runner),
     returning = returning_json("AvailableReports.schema")
   )
 }
 
 target_report_parameters <- function(runner, report_id, commit = NULL) {
+  args <- set_param_defaults(target_report_parameters, as.list(environment()))
+  list2env(args, envir = environment())
   path <- runner$root
   default_branch <- runner$default_branch
   tryCatch(
@@ -194,6 +200,8 @@ endpoint_report_parameters <- function(runner) {
 
 target_bundle_pack <- function(path, name, parameters = NULL,
                                instance = NULL) {
+  args <- set_param_defaults(target_bundle_pack, as.list(environment()))
+  list2env(args, envir = environment())
   if (!is.null(parameters)) {
     parameters <- jsonlite::fromJSON(parameters)
   }
@@ -236,6 +244,8 @@ endpoint_bundle_import <- function(path, data) {
 }
 
 target_report_info <- function(runner, id, name) {
+  args <- set_param_defaults(target_report_info, as.list(environment()))
+  list2env(args, envir = environment())
   info <- orderly::orderly_info(id, name, root = runner$root)
   info <- recursive_scalar(info)
   ## Rename parameters to params for consistency with rest of API
@@ -247,8 +257,8 @@ target_report_info <- function(runner, id, name) {
 endpoint_report_info <- function(runner) {
   porcelain::porcelain_endpoint$new(
     "GET", "/v1/reports/info", target_report_info,
-    porcelain::porcelain_input_query(id = "string"),
-    porcelain::porcelain_input_query(name = "string"),
+    porcelain::porcelain_input_query(id = "string",
+                                     name = "string"),
     porcelain::porcelain_state(runner = runner),
     returning = returning_json("ReportInfo.schema")
   )
@@ -256,6 +266,8 @@ endpoint_report_info <- function(runner) {
 
 target_run <- function(runner, name, body = NULL, ref = NULL,
                        instance = NULL, timeout = 60 * 60 * 3) {
+  args <- set_param_defaults(target_run, as.list(environment()))
+  list2env(args, envir = environment())
   if (!is.null(body)) {
     body <- jsonlite::fromJSON(body)
   }
@@ -281,6 +293,8 @@ endpoint_run <- function(runner) {
 }
 
 target_status <- function(runner, key, output = FALSE) {
+  args <- set_param_defaults(target_status, as.list(environment()))
+  list2env(args, envir = environment())
   res <- runner$status(key, output)
   queue <- res$queue
   if (is.null(queue)) {
@@ -336,6 +350,8 @@ target_dependencies <- function(runner, name,
                                 max_depth = 100,
                                 show_all = FALSE,
                                 use = "archive") {
+  args <- set_param_defaults(target_dependencies, as.list(environment()))
+  list2env(args, envir = environment())
   get_dependencies(path = runner$root,
                    name = name,
                    id = id,
@@ -437,6 +453,8 @@ endpoint_workflow_run <- function(runner) {
 }
 
 target_workflow_status <- function(runner, workflow_key, output = FALSE) {
+  args <- set_param_defaults(target_workflow_status, as.list(environment()))
+  list2env(args, envir = environment())
   res <- runner$workflow_status(workflow_key, output)
   reports <- lapply(res$reports, function(report) {
     list(
@@ -495,6 +513,8 @@ endpoint_report_version_artefact_hashes <- function(path) {
 }
 
 target_reports <- function(path, reports = NULL) {
+  args <- set_param_defaults(target_reports, as.list(environment()))
+  list2env(args, envir = environment())
   if (!is.null(reports)) {
     reports <- unlist(strsplit(reports, split = ","))
   }
@@ -572,6 +592,9 @@ endpoint_report_version_details <- function(path) {
 }
 
 target_report_versions_custom_fields <- function(path, versions) {
+  args <- set_param_defaults(target_report_versions_custom_fields,
+                     as.list(environment()))
+  list2env(args, envir = environment())
   db <- orderly::orderly_db("destination", root = path)
   get_custom_fields_for_versions(db, unlist(strsplit(versions, split = ",")))
 }
@@ -605,6 +628,8 @@ endpoint_custom_fields <- function(path) {
 }
 
 target_report_versions_params <- function(path, versions) {
+  args <- set_param_defaults(target_report_versions_params, as.list(environment()))
+  list2env(args, envir = environment())
   db <- orderly::orderly_db("destination", root = path)
   get_parameters_for_versions(db, unlist(strsplit(versions, split = ",")))
 }
@@ -671,6 +696,8 @@ target_report_version_changelog <- function(path,
                                             name,
                                             id,
                                             public_only = FALSE) {
+  args <- set_param_defaults(target_report_version_changelog, as.list(environment()))
+  list2env(args, envir = environment())
   db <- orderly::orderly_db("destination", root = path)
   version <- get_report_version(db, name, id)
   if (public_only) {

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -182,3 +182,28 @@ test_that("is_empty", {
   expect_true(is_empty(""))
   expect_false(is_empty("text"))
 })
+
+test_that("set_param_defaults", {
+  f <- function(w, x, y = NULL, z = "default") {}
+
+  args <- set_param_defaults(f, list(x = "thing"))
+  expect_equal(args, list(x = "thing"))
+
+  args <- set_param_defaults(f, list(x = "thing", y = NA, z = NA_character_))
+  expect_equal(args,
+               list(x = "thing", y = NULL, z = "default"))
+
+  args <- set_param_defaults(f, list(x = "thing", y = "y", z = "z"))
+  expect_equal(args,
+               list(x = "thing", y = "y", z = "z"))
+
+  args <- set_param_defaults(f, list(x = "thing", y = NULL, z = ""))
+  expect_equal(args,
+               list(x = "thing", y = NULL, z = ""))
+
+  expect_error(set_param_defaults(f, list(x = NA, y = 2, z = "")),
+               "query parameter 'x' is missing but required")
+
+  expect_error(set_param_defaults(f, list(w = NA, x = NA, y = 2, z = "")),
+               "query parameters 'w', 'x' are missing but required")
+})

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -184,7 +184,7 @@ test_that("is_empty", {
 })
 
 test_that("set_param_defaults", {
-  f <- function(w, x, y = NULL, z = "default") {}
+  f <- function(w, x, y = NULL, z = "default") {} # nolint
 
   args <- set_param_defaults(f, list(x = "thing"))
   expect_equal(args, list(x = "thing"))


### PR DESCRIPTION
- [x] spec.md has been updated or doesn't need to updated

This PR will update endpoints which take a query parameter to handle receiving `NA` as a query parameter. This has changed since https://github.com/reside-ic/porcelain/pull/31. Now if users set `/path?param=` `param` now comes through as `NA` whereas before it would have been unset (and so used the default value).

What this change does is
* If the target function has no default then it will error if `param` is NA with message `query parameters 'param' are missing but required` this is the same as the error you would get if you queried `/path` without any parameters (e.g. `/git/commits` endpoint)
* If the target function has a default then it will set the value of `param` to that default value, this is the behaviour you would get if queried `/path` without any parameters (e.g. /v1/reports/<name>/run/` endpoint)

This is really ugly and it might have just been simpler to add individual handling in each target function for an NA arg. That would require much more testing but let me know what you think. Maybe you have some good ideas for making the current impl tidier?

I mentioned before but I am still not super convinced about the change to porcelain. I'm not sure if there is a scenario where you would want your API to have a different behaviour when hitting `/path` compared to `/path?param=`