### PR TITLE
Setup builds to be triggered by orderly

### DIFF
--- a/.github/workflows/R-CMD-check-mac.yaml
+++ b/.github/workflows/R-CMD-check-mac.yaml
@@ -5,12 +5,10 @@ on:
     branches:
       - main
       - master
-      - vimc-4192
   pull_request:
     branches:
       - main
       - master
-      - vimc-4192
 
 name: R-CMD-check
 
@@ -67,7 +65,12 @@ jobs:
           remotes::install_cran("rcmdcheck")
           remotes::install_github("mrc-ide/rrq")
           remotes::install_github("ropensci/jsonvalidate")
-          remotes::install_github("reside-ic/porcelain@22eef9b")
+        shell: Rscript {0}
+
+
+      - name: Install development orderly
+        if: ${{ env.ORDERLY_VERSION != 'master' }}
+        run: remotes::install_github("vimc/orderly@$ORDERLY_VERSION")
         shell: Rscript {0}
 
       - name: Check

--- a/.github/workflows/R-CMD-check-mac.yaml
+++ b/.github/workflows/R-CMD-check-mac.yaml
@@ -9,6 +9,8 @@ on:
     branches:
       - main
       - master
+  repository_dispatch:
+    types: [orderly-downstream]
 
 name: R-CMD-check
 
@@ -69,7 +71,9 @@ jobs:
 
 
       - name: Install development orderly
-        if: ${{ env.ORDERLY_VERSION != 'master' }}
+        if: ${{ github.event.name == 'repository-dispatch' }} && ${{ github.event.client_payload.orderly_version != 'master' }}
+        env:
+          ORDERLY_VERION: ${{ github.event.client_payload.orderly_version }}
         run: remotes::install_github("vimc/orderly@$ORDERLY_VERSION")
         shell: Rscript {0}
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -5,12 +5,10 @@ on:
     branches:
       - main
       - master
-      - vimc-4192
   pull_request:
     branches:
       - main
       - master
-      - vimc-4192
 
 name: R-CMD-check
 
@@ -44,6 +42,7 @@ jobs:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      ORDERLY_VERSION: master
 
     steps:
       - uses: actions/checkout@v2
@@ -84,7 +83,11 @@ jobs:
           remotes::install_cran("rcmdcheck")
           remotes::install_github("mrc-ide/rrq")
           remotes::install_github("ropensci/jsonvalidate")
-          remotes::install_github("reside-ic/porcelain@22eef9b")
+        shell: Rscript {0}
+
+      - name: Install development orderly
+        if: ${{ env.ORDERLY_VERSION != 'master' }}
+        run: remotes::install_github("vimc/orderly@$ORDERLY_VERSION")
         shell: Rscript {0}
 
       - name: Check

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -9,6 +9,8 @@ on:
     branches:
       - main
       - master
+  repository_dispatch:
+    types: [orderly-downstream]
 
 name: R-CMD-check
 
@@ -42,7 +44,6 @@ jobs:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      ORDERLY_VERSION: master
 
     steps:
       - uses: actions/checkout@v2
@@ -86,7 +87,9 @@ jobs:
         shell: Rscript {0}
 
       - name: Install development orderly
-        if: ${{ env.ORDERLY_VERSION != 'master' }}
+        if: ${{ github.event.name == 'repository-dispatch' }} && ${{ github.event.client_payload.orderly_version != 'master' }}
+        env:
+          ORDERLY_VERION: ${{ github.event.client_payload.orderly_version }}
         run: remotes::install_github("vimc/orderly@$ORDERLY_VERSION")
         shell: Rscript {0}
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -63,7 +63,6 @@ jobs:
           remotes::install_cran("rcmdcheck")
           remotes::install_github("mrc-ide/rrq")
           remotes::install_github("ropensci/jsonvalidate")
-          remotes::install_github("reside-ic/porcelain@22eef9b")
         shell: Rscript {0}
 
       - name: Install package

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -7,6 +7,8 @@ on:
     branches:
       - main
       - master
+  repository_dispatch:
+    types: [orderly-downstream]
 
 name: test-coverage
 
@@ -70,7 +72,9 @@ jobs:
         shell: Rscript {0}
 
       - name: Install development orderly
-        if: ${{ env.ORDERLY_VERSION != 'master' }}
+        if: ${{ github.event.name == 'repository-dispatch' }} && ${{ github.event.client_payload.orderly_version != 'master' }}
+        env:
+          ORDERLY_VERION: ${{ github.event.client_payload.orderly_version }}
         run: remotes::install_github("vimc/orderly@$ORDERLY_VERSION")
         shell: Rscript {0}
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -3,12 +3,10 @@ on:
     branches:
       - main
       - master
-      - vimc-4192
   pull_request:
     branches:
       - main
       - master
-      - vimc-4192
 
 name: test-coverage
 
@@ -68,8 +66,12 @@ jobs:
           remotes::install_deps(dependencies = TRUE)
           remotes::install_github("mrc-ide/rrq")
           remotes::install_github("ropensci/jsonvalidate")
-          remotes::install_github("reside-ic/porcelain@22eef9b")
           remotes::install_cran("covr")
+        shell: Rscript {0}
+
+      - name: Install development orderly
+        if: ${{ env.ORDERLY_VERSION != 'master' }}
+        run: remotes::install_github("vimc/orderly@$ORDERLY_VERSION")
         shell: Rscript {0}
 
       - name: Test coverage

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM vimc/orderly:master
+ARG BASE_IMAGE_TAG=master
+FROM vimc/orderly:${BASE_IMAGE_TAG}
 
 RUN apt-get update || apt-get update && apt-get install -y \
   libcurl4-openssl-dev \
@@ -10,17 +11,17 @@ RUN apt-get update || apt-get update && apt-get install -y \
 COPY docker/bin /usr/local/bin/
 
 RUN install2.r --error \
-        --repos https://cloud.r-project.org \
-        --repos https://mrc-ide.r-universe.dev \
-        callr \
-        jsonlite \
-        jsonvalidate \
-        lgr \
-        porcelain \
-        processx \
-        remotes \
-        rrq \
-        webutils
+  --repos https://cloud.r-project.org \
+  --repos https://mrc-ide.r-universe.dev \
+  callr \
+  jsonlite \
+  jsonvalidate \
+  lgr \
+  porcelain \
+  processx \
+  remotes \
+  rrq \
+  webutils
 
 COPY . /src
 

--- a/docker/build
+++ b/docker/build
@@ -8,7 +8,7 @@ ORDERLY_VERSION="${ORDERLY_VERSION:-master}"
 docker build --pull \
        -t $TAG_SHA \
        -f docker/Dockerfile \
-       -build-arg "BASE_IMAGE_TAG=${ORDERLY_VERSION}" \
+       --build-arg "BASE_IMAGE_TAG=${ORDERLY_VERSION}" \
        $PACKAGE_ROOT
 
 # We always push the SHA tagged versions, for debugging if the tests

--- a/docker/build
+++ b/docker/build
@@ -3,9 +3,12 @@ set -ex
 HERE=$(dirname $0)
 . $HERE/common
 
+ORDERLY_VERSION="${ORDERLY_VERSION:-master}"
+
 docker build --pull \
        -t $TAG_SHA \
        -f docker/Dockerfile \
+       -build-arg "BASE_IMAGE_TAG=${ORDERLY_VERSION}" \
        $PACKAGE_ROOT
 
 # We always push the SHA tagged versions, for debugging if the tests


### PR DESCRIPTION
- [x] spec.md has been updated or doesn't need to updated

For buildkite this PR will
* Use env var to set orderly branch/ref as base image

For gh actions
* Setup a repository_dispatch trigger see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#repository_dispatch
* Install development version of orderly if this is a repository_dispatch with id non master