### PR TITLE
Use image tagged with SHA and orderly SHA when orderly branch is not default

### DIFF
--- a/docker/build
+++ b/docker/build
@@ -3,8 +3,6 @@ set -ex
 HERE=$(dirname $0)
 . $HERE/common
 
-ORDERLY_VERSION="${ORDERLY_VERSION:-master}"
-
 docker build --pull \
        -t $TAG_SHA \
        -f docker/Dockerfile \

--- a/docker/common
+++ b/docker/common
@@ -2,8 +2,8 @@
 PACKAGE_ROOT=$(realpath $HERE/..)
 PACKAGE_NAME=orderly.server
 PACKAGE_ORG=vimc
-PACKAGE_VERSION=$(cat $PACKAGE_ROOT/DESCRIPTION | \
-                      grep '^Version:' | sed 's/^.*: *//')
+PACKAGE_VERSION=$(cat $PACKAGE_ROOT/DESCRIPTION |
+    grep '^Version:' | sed 's/^.*: *//')
 
 # Buildkite doesn't check out a full history from the remote (just the
 # single commit) so you end up with a detached head and git rev-parse
@@ -25,3 +25,14 @@ fi
 TAG_SHA="${PACKAGE_ORG}/${PACKAGE_NAME}:${GIT_SHA}"
 TAG_BRANCH="${PACKAGE_ORG}/${PACKAGE_NAME}:${GIT_BRANCH}"
 TAG_LATEST="${PACKAGE_ORG}/${PACKAGE_NAME}:latest"
+
+## ORDERLY_VERSION can be set as an env var to trigger a build
+## of orderly.server with a specific version of orderly. If
+## the orderly version is not the default branch then use a
+## combined tag so that we never replace an existing tagged
+## image built off master with an image with a different
+## version of orderly installed
+ORDERLY_VERSION="${ORDERLY_VERSION:-master}"
+if [ "$ORDERLY_VERSION" != "master" ]; then
+    TAG_SHA="$TAG_SHA-$ORDERLY_VERSION"
+fi


### PR DESCRIPTION
- [x] spec.md has been updated or doesn't need to updated

This is to support https://github.com/vimc/orderly/pull/321#issuecomment-1289031972