### PR TITLE
Print inputs when running triggered R CMD check

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -50,6 +50,11 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
+      steps:
+      - name: Inputs
+        if: ${{ github.event.name == 'workflow-dispatch' }}
+        run: echo "${{ toJSON(github.event.inputs) }}"
+
       - uses: actions/checkout@v2
 
       - uses: r-lib/actions/setup-r@v1

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -56,11 +56,11 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - name: Query dependencies
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -50,7 +50,6 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      steps:
       - name: Inputs
         if: ${{ github.event.name == 'workflow-dispatch' }}
         run: echo "${{ toJSON(github.event.inputs) }}"

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Inputs
-        if: ${{ github.event.name == 'workflow-dispatch' }}
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         run: echo "${{ toJSON(github.event.inputs) }}"
 
       - uses: actions/checkout@v2
@@ -95,7 +95,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Install development orderly
-        if: ${{ github.event.name == 'workflow-dispatch' && github.event.inputs.orderly_version != 'master' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.orderly_version != 'master' }}
         env:
           ORDERLY_VERSION: ${{ github.event.inputs.orderly_version }}
         run: |


### PR DESCRIPTION
- [x] spec.md has been updated or doesn't need to updated

I've triggered this action using curl

```
curl \
  -X POST \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer token" \
  https://api.github.com/repos/vimc/orderly.server/actions/workflows/R-CMD-check.yaml/dispatches \
  -d '{"ref":"print-inputs","inputs":{"orderly_version":"ae1dc07"}}'
```

You can see the output here

https://github.com/vimc/orderly.server/actions/runs/3384967627/jobs/5622565896
