### PR TITLE
Trigger orderly-web build from test pipeline

### DIFF
--- a/buildkite/test-pipeline.yml
+++ b/buildkite/test-pipeline.yml
@@ -12,4 +12,4 @@ steps:
     label: ":rocket: orderly-web (from orderly.server) :cloud:"
     build:
       env:
-        ORDERLY_SERVER_VERSION: $(buildkite-agent meta-data get "orderly-server-sha")
+        ORDERLY_SERVER_VERSION: "${buildkite-agent meta-data get \"orderly-server-sha\"}"

--- a/buildkite/test-pipeline.yml
+++ b/buildkite/test-pipeline.yml
@@ -6,3 +6,10 @@ steps:
 
   - label: ":hammer: Test"
     command: docker/test
+
+  # The next step triggers orderly-web build using the branch
+  - trigger: "orderly-web"
+    label: ":rocket: orderly-web (from orderly.server) :cloud:"
+    build:
+      env:
+        ORDERLY_SERVER_VERSION: $(buildkite-agent meta-data get "orderly-server-sha")

--- a/docker/common
+++ b/docker/common
@@ -35,4 +35,5 @@ TAG_LATEST="${PACKAGE_ORG}/${PACKAGE_NAME}:latest"
 ORDERLY_VERSION="${ORDERLY_VERSION:-master}"
 if [ "$ORDERLY_VERSION" != "master" ]; then
     TAG_SHA="$TAG_SHA-$ORDERLY_VERSION"
+    buildkite-agent meta-data set "orderly-server-sha" $TAG_SHA
 fi


### PR DESCRIPTION
- [x] spec.md has been updated or doesn't need to updated

This PR will trigger orderly-web build from the orderly.server test pipeline. The orderly.server test pipeline is run on a build triggered on orderly changes. This will mean that when we make a new orderly PR it will trigger the orderly.server test pipeline which will trigger and orderly-web test build. It will use the $TAG_SHA which is already a combined tag on triggered builds since #124 